### PR TITLE
[oneMKL][RNG] Fixed some bugs for oneMKL RNG device API 

### DIFF
--- a/source/elements/oneMKL/source/domains/rng/device_api/device-rng-mcg31m1.rst
+++ b/source/elements/oneMKL/source/domains/rng/device_api/device-rng-mcg31m1.rst
@@ -45,7 +45,6 @@ class mcg31m1
        
        mcg31m1();
        mcg31m1(std::uint32_t seed, std::uint64_t offset = 0);
-       mcg31m1(std::initializer_list<std::uint32_t> seed, std::uint64_t offset = 0);
      };
    }
 
@@ -71,8 +70,6 @@ class mcg31m1
           - Default constructor
         * - `mcg31m1(std::uint32_t seed, std::uint64_t offset = 0)`_
           - Constructor for common seed initialization of the engine and common number of skipped elements
-        * - `mcg31m1(std::initializer_list<std::uint32_t> seed, std::uint64_t offset = 0)`_
-          - Constructor for extended seed initialization of the engine and common number of skipped elements
 
 .. container:: section
 
@@ -89,23 +86,6 @@ class mcg31m1
     .. code-block:: cpp
     
         mcg31m1::mcg31m1(std::uint32_t seed, std::uint64_t offset = 0)
-
-    .. container:: section
-
-        .. rubric:: Input Parameters
-
-        seed
-            The initial conditions of the generator state, assume :math:`x_0 = seed \ mod \ 0x7FFFFFFF`, 
-            if :math:`x_0 = 0`, assume :math:`x_0 = 1`.
-        
-        offset
-            Number of skipped elements.
-            
-    .. _`mcg31m1(std::initializer_list<std::uint32_t> seed, std::uint64_t offset = 0)`:
-
-    .. code-block:: cpp
-    
-        mcg31m1::mcg31m1(std::initializer_list<std::uint32_t> seed, std::uint64_t offset = 0)
 
     .. container:: section
 

--- a/source/elements/oneMKL/source/domains/rng/device_api/device-rng-mcg59.rst
+++ b/source/elements/oneMKL/source/domains/rng/device_api/device-rng-mcg59.rst
@@ -40,8 +40,7 @@ class mcg59
        static constexpr std::int32_t vec_size = VecSize;
        
        mcg59();
-       mcg59(std::uint32_t seed, std::uint64_t offset = 0);
-       mcg59(std::initializer_list<std::uint32_t> seed, std::uint64_t offset = 0);
+       mcg59(std::uint64_t seed, std::uint64_t offset = 0);
      };
    }
 
@@ -65,10 +64,8 @@ class mcg59
           - Description
         * - `mcg59()`_
           - Default constructor
-        * - `mcg59(std::uint32_t seed, std::uint64_t offset = 0)`_
+        * - `mcg59(std::uint64_t seed, std::uint64_t offset = 0)`_
           - Constructor for common seed initialization of the engine and common number of skipped elements
-        * - `mcg59(std::initializer_list<std::uint32_t> seed, std::uint64_t offset = 0)`_
-          - Constructor for extended seed initialization of the engine and common number of skipped elements
 
 .. container:: section
 
@@ -80,28 +77,11 @@ class mcg59
     
         mcg59::mcg59()
 
-    .. _`mcg59(std::uint32_t seed, std::uint64_t offset = 0)`:
+    .. _`mcg59(std::uint64_t seed, std::uint64_t offset = 0)`:
 
     .. code-block:: cpp
     
-        mcg59::mcg59(std::uint32_t seed, std::uint64_t offset = 0)
-
-    .. container:: section
-
-        .. rubric:: Input Parameters
-
-        seed
-            The initial conditions of the generator state, assume :math:`x_0 = seed \ mod \ 2^{59}`, 
-            if :math:`x_0 = 0`, assume :math:`x_0 = 1`.
-        
-        offset
-            Number of skipped elements.
-            
-    .. _`mcg59(std::initializer_list<std::uint32_t> seed, std::uint64_t offset = 0)`:
-
-    .. code-block:: cpp
-    
-        mcg59::mcg59(std::initializer_list<std::uint32_t> seed, std::uint64_t offset = 0)
+        mcg59::mcg59(std::uint64_t seed, std::uint64_t offset = 0)
 
     .. container:: section
 


### PR DESCRIPTION
It doesn't make sense to keep constructors with `std::initializer_list` for `mcg31m1` and `mcg59` generators since one `seed` value is enough. Due to size of the state for `mcg31m1` uint32_t is enough to store it. For `mcg59` uint64_t is enough. So, let's keep only `std::uint32_t seed` for `mcg31m1` and `std::uint64_t seed` for `mcg59`.

Feel free to provide your feedback.