### PR TITLE
[OneMKL] Replace `onemkl::` with `oneapi::mkl::`

### DIFF
--- a/source/elements/oneMKL/source/domains/blas/dgmm_batch.rst
+++ b/source/elements/oneMKL/source/domains/blas/dgmm_batch.rst
@@ -248,7 +248,7 @@ in ``a`` and ``x`` are given by the ``batch_size`` parameter.
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event dgmm_batch(sycl::queue &queue,
-                              const oneapi::mkl::mkl::side *left_right,
+                              const oneapi::mkl::side *left_right,
                               const std::int64_t *m,
                               const std::int64_t *n,
                               const T **a,

--- a/source/elements/oneMKL/source/domains/blas/dgmm_batch.rst
+++ b/source/elements/oneMKL/source/domains/blas/dgmm_batch.rst
@@ -81,7 +81,7 @@ of matrices in ``a`` and ``x`` buffers is given by the ``batch_size`` parameter.
 
    namespace oneapi::mkl::blas::row_major {
        void dgmm_batch(sycl::queue &queue,
-                       oneapi::mkl::mkl::side left_right,
+                       oneapi::mkl::side left_right,
                        std::int64_t m,
                        std::int64_t n,
                        sycl::buffer<T,1> &a,

--- a/source/elements/oneMKL/source/domains/blas/dgmm_batch.rst
+++ b/source/elements/oneMKL/source/domains/blas/dgmm_batch.rst
@@ -265,7 +265,7 @@ in ``a`` and ``x`` are given by the ``batch_size`` parameter.
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event dgmm_batch(sycl::queue &queue,
-                              const oneapi::mkl::mkl::side *left_right,
+                              const oneapi::mkl::side *left_right,
                               const std::int64_t *m,
                               const std::int64_t *n,
                               const T **a,

--- a/source/elements/oneMKL/source/domains/blas/dgmm_batch.rst
+++ b/source/elements/oneMKL/source/domains/blas/dgmm_batch.rst
@@ -372,7 +372,7 @@ in ``a`` and ``x`` are given by the ``batch_size`` parameter.
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event dgmm_batch(sycl::queue &queue,
-                              oneapi::mkl::mkl::side left_right,
+                              oneapi::mkl::side left_right,
                               std::int64_t m,
                               std::int64_t n,
                               const T *a,

--- a/source/elements/oneMKL/source/domains/blas/dgmm_batch.rst
+++ b/source/elements/oneMKL/source/domains/blas/dgmm_batch.rst
@@ -63,7 +63,7 @@ of matrices in ``a`` and ``x`` buffers is given by the ``batch_size`` parameter.
 
    namespace oneapi::mkl::blas::column_major {
        void dgmm_batch(sycl::queue &queue,
-                       oneapi::mkl::mkl::side left_right,
+                       oneapi::mkl::side left_right,
                        std::int64_t m,
                        std::int64_t n,
                        sycl::buffer<T,1> &a,

--- a/source/elements/oneMKL/source/domains/blas/dgmm_batch.rst
+++ b/source/elements/oneMKL/source/domains/blas/dgmm_batch.rst
@@ -63,7 +63,7 @@ of matrices in ``a`` and ``x`` buffers is given by the ``batch_size`` parameter.
 
    namespace oneapi::mkl::blas::column_major {
        void dgmm_batch(sycl::queue &queue,
-                       onemkl::mkl::side left_right,
+                       oneapi::mkl::mkl::side left_right,
                        std::int64_t m,
                        std::int64_t n,
                        sycl::buffer<T,1> &a,
@@ -81,7 +81,7 @@ of matrices in ``a`` and ``x`` buffers is given by the ``batch_size`` parameter.
 
    namespace oneapi::mkl::blas::row_major {
        void dgmm_batch(sycl::queue &queue,
-                       onemkl::mkl::side left_right,
+                       oneapi::mkl::mkl::side left_right,
                        std::int64_t m,
                        std::int64_t n,
                        sycl::buffer<T,1> &a,
@@ -248,7 +248,7 @@ in ``a`` and ``x`` are given by the ``batch_size`` parameter.
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event dgmm_batch(sycl::queue &queue,
-                              const onemkl::mkl::side *left_right,
+                              const oneapi::mkl::mkl::side *left_right,
                               const std::int64_t *m,
                               const std::int64_t *n,
                               const T **a,
@@ -265,7 +265,7 @@ in ``a`` and ``x`` are given by the ``batch_size`` parameter.
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event dgmm_batch(sycl::queue &queue,
-                              const onemkl::mkl::side *left_right,
+                              const oneapi::mkl::mkl::side *left_right,
                               const std::int64_t *m,
                               const std::int64_t *n,
                               const T **a,
@@ -372,7 +372,7 @@ in ``a`` and ``x`` are given by the ``batch_size`` parameter.
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event dgmm_batch(sycl::queue &queue,
-                              onemkl::mkl::side left_right,
+                              oneapi::mkl::mkl::side left_right,
                               std::int64_t m,
                               std::int64_t n,
                               const T *a,
@@ -391,7 +391,7 @@ in ``a`` and ``x`` are given by the ``batch_size`` parameter.
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event dgmm_batch(sycl::queue &queue,
-                              onemkl::mkl::side left_right,
+                              oneapi::mkl::mkl::side left_right,
                               std::int64_t m,
                               std::int64_t n,
                               const T *a,

--- a/source/elements/oneMKL/source/domains/blas/dgmm_batch.rst
+++ b/source/elements/oneMKL/source/domains/blas/dgmm_batch.rst
@@ -391,7 +391,7 @@ in ``a`` and ``x`` are given by the ``batch_size`` parameter.
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event dgmm_batch(sycl::queue &queue,
-                              oneapi::mkl::mkl::side left_right,
+                              oneapi::mkl::side left_right,
                               std::int64_t m,
                               std::int64_t n,
                               const T *a,

--- a/source/elements/oneMKL/source/domains/blas/gbmv.rst
+++ b/source/elements/oneMKL/source/domains/blas/gbmv.rst
@@ -55,7 +55,7 @@ gbmv (Buffer Version)
 
    namespace oneapi::mkl::blas::column_major {
        void gbmv(sycl::queue &queue,
-                 onemkl::transpose trans,
+                 oneapi::mkl::transpose trans,
                  std::int64_t m,
                  std::int64_t n,
                  std::int64_t kl,
@@ -73,7 +73,7 @@ gbmv (Buffer Version)
 
    namespace oneapi::mkl::blas::row_major {
        void gbmv(sycl::queue &queue,
-                 onemkl::transpose trans,
+                 oneapi::mkl::transpose trans,
                  std::int64_t m,
                  std::int64_t n,
                  std::int64_t kl,
@@ -190,7 +190,7 @@ gbmv (USM Version)
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event gbmv(sycl::queue &queue,
-                        onemkl::transpose trans,
+                        oneapi::mkl::transpose trans,
                         std::int64_t m,
                         std::int64_t n,
                         std::int64_t kl,
@@ -209,7 +209,7 @@ gbmv (USM Version)
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event gbmv(sycl::queue &queue,
-                        onemkl::transpose trans,
+                        oneapi::mkl::transpose trans,
                         std::int64_t m,
                         std::int64_t n,
                         std::int64_t kl,

--- a/source/elements/oneMKL/source/domains/blas/gemm.rst
+++ b/source/elements/oneMKL/source/domains/blas/gemm.rst
@@ -101,8 +101,8 @@ gemm (Buffer Version)
 
    namespace oneapi::mkl::blas::column_major {
        void gemm(sycl::queue &queue,
-                 onemkl::transpose transa,
-                 onemkl::transpose transb,
+                 oneapi::mkl::transpose transa,
+                 oneapi::mkl::transpose transb,
                  std::int64_t m,
                  std::int64_t n,
                  std::int64_t k,
@@ -119,8 +119,8 @@ gemm (Buffer Version)
 
    namespace oneapi::mkl::blas::row_major {
        void gemm(sycl::queue &queue,
-                 onemkl::transpose transa,
-                 onemkl::transpose transb,
+                 oneapi::mkl::transpose transa,
+                 oneapi::mkl::transpose transb,
                  std::int64_t m,
                  std::int64_t n,
                  std::int64_t k,
@@ -303,8 +303,8 @@ gemm (USM Version)
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event gemm(sycl::queue &queue,
-                        onemkl::transpose transa,
-                        onemkl::transpose transb,
+                        oneapi::mkl::transpose transa,
+                        oneapi::mkl::transpose transb,
                         std::int64_t m,
                         std::int64_t n,
                         std::int64_t k,
@@ -322,8 +322,8 @@ gemm (USM Version)
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event gemm(sycl::queue &queue,
-                        onemkl::transpose transa,
-                        onemkl::transpose transb,
+                        oneapi::mkl::transpose transa,
+                        oneapi::mkl::transpose transb,
                         std::int64_t m,
                         std::int64_t n,
                         std::int64_t k,

--- a/source/elements/oneMKL/source/domains/blas/gemm_batch.rst
+++ b/source/elements/oneMKL/source/domains/blas/gemm_batch.rst
@@ -111,8 +111,8 @@ of matrices in ``a``, ``b`` and ``c`` buffers is given by the ``batch_size`` par
 
    namespace oneapi::mkl::blas::column_major {
        void gemm_batch(sycl::queue &queue,
-                       onemkl::transpose transa,
-                       onemkl::transpose transb,
+                       oneapi::mkl::transpose transa,
+                       oneapi::mkl::transpose transb,
                        std::int64_t m,
                        std::int64_t n,
                        std::int64_t k,
@@ -133,8 +133,8 @@ of matrices in ``a``, ``b`` and ``c`` buffers is given by the ``batch_size`` par
 
    namespace oneapi::mkl::blas::row_major {
        void gemm_batch(sycl::queue &queue,
-                       onemkl::transpose transa,
-                       onemkl::transpose transb,
+                       oneapi::mkl::transpose transa,
+                       oneapi::mkl::transpose transb,
                        std::int64_t m,
                        std::int64_t n,
                        std::int64_t k,
@@ -358,8 +358,8 @@ in ``a``, ``b`` and ``c`` are given by the ``batch_size`` parameter.
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event gemm_batch(sycl::queue &queue,
-                              const onemkl::transpose *transa,
-                              const onemkl::transpose *transb,
+                              const oneapi::mkl::transpose *transa,
+                              const oneapi::mkl::transpose *transb,
                               const std::int64_t *m,
                               const std::int64_t *n,
                               const std::int64_t *k,
@@ -376,8 +376,8 @@ in ``a``, ``b`` and ``c`` are given by the ``batch_size`` parameter.
                               const std::vector<sycl::event> &dependencies = {})
 
        sycl::event gemm_batch(sycl::queue &queue,
-                              const sycl::span<onemkl::transpose> &transa,
-                              const sycl::span<onemkl::transpose> &transb,
+                              const sycl::span<oneapi::mkl::transpose> &transa,
+                              const sycl::span<oneapi::mkl::transpose> &transb,
                               const sycl::span<std::int64_t> &m,
                               const sycl::span<std::int64_t> &n,
                               const sycl::span<std::int64_t> &k,
@@ -397,8 +397,8 @@ in ``a``, ``b`` and ``c`` are given by the ``batch_size`` parameter.
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event gemm_batch(sycl::queue &queue,
-                              const onemkl::transpose *transa,
-                              const onemkl::transpose *transb,
+                              const oneapi::mkl::transpose *transa,
+                              const oneapi::mkl::transpose *transb,
                               const std::int64_t *m,
                               const std::int64_t *n,
                               const std::int64_t *k,
@@ -415,8 +415,8 @@ in ``a``, ``b`` and ``c`` are given by the ``batch_size`` parameter.
                               const std::vector<sycl::event> &dependencies = {})
 
        sycl::event gemm_batch(sycl::queue &queue,
-                              const sycl::span<onemkl::transpose> &transa,
-                              const sycl::span<onemkl::transpose> &transb,
+                              const sycl::span<oneapi::mkl::transpose> &transa,
+                              const sycl::span<oneapi::mkl::transpose> &transb,
                               const sycl::span<std::int64_t> &m,
                               const sycl::span<std::int64_t> &n,
                               const sycl::span<std::int64_t> &k,
@@ -441,11 +441,11 @@ in ``a``, ``b`` and ``c`` are given by the ``batch_size`` parameter.
       The queue where the routine should be executed.
 
    transa
-      Array or span of ``group_count`` ``onemkl::transpose`` values. ``transa[i]`` specifies the form of op(``A``) used in
+      Array or span of ``group_count`` ``oneapi::mkl::transpose`` values. ``transa[i]`` specifies the form of op(``A``) used in
       the matrix multiplication in group ``i``. See :ref:`onemkl_datatypes` for more details.
 
    transb
-      Array or span of ``group_count`` ``onemkl::transpose`` values. ``transb[i]`` specifies the form of op(``B``) used in
+      Array or span of ``group_count`` ``oneapi::mkl::transpose`` values. ``transb[i]`` specifies the form of op(``B``) used in
       the matrix multiplication in group ``i``. See :ref:`onemkl_datatypes` for more details.
 
    m
@@ -588,8 +588,8 @@ in ``a``, ``b`` and ``c`` are given by the ``batch_size`` parameter.
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event gemm_batch(sycl::queue &queue,
-                              onemkl::transpose transa,
-                              onemkl::transpose transb,
+                              oneapi::mkl::transpose transa,
+                              oneapi::mkl::transpose transb,
                               std::int64_t m,
                               std::int64_t n,
                               std::int64_t k,
@@ -611,8 +611,8 @@ in ``a``, ``b`` and ``c`` are given by the ``batch_size`` parameter.
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event gemm_batch(sycl::queue &queue,
-                              onemkl::transpose transa,
-                              onemkl::transpose transb,
+                              oneapi::mkl::transpose transa,
+                              oneapi::mkl::transpose transb,
                               std::int64_t m,
                               std::int64_t n,
                               std::int64_t k,

--- a/source/elements/oneMKL/source/domains/blas/gemm_bias.rst
+++ b/source/elements/oneMKL/source/domains/blas/gemm_bias.rst
@@ -67,9 +67,9 @@ gemm_bias (Buffer Version)
 
    namespace oneapi::mkl::blas::column_major {
        void gemm_bias(sycl::queue &queue,
-                      onemkl::transpose transa,
-                      onemkl::transpose transb,
-                      onemkl::offset offset_type,
+                      oneapi::mkl::transpose transa,
+                      oneapi::mkl::transpose transb,
+                      oneapi::mkl::offset offset_type,
                       std::int64_t m,
                       std::int64_t n,
                       std::int64_t k,
@@ -89,9 +89,9 @@ gemm_bias (Buffer Version)
 
    namespace oneapi::mkl::blas::row_major {
        void gemm_bias(sycl::queue &queue,
-                      onemkl::transpose transa,
-                      onemkl::transpose transb,
-                      onemkl::offset offset_type,
+                      oneapi::mkl::transpose transa,
+                      oneapi::mkl::transpose transb,
+                      oneapi::mkl::offset offset_type,
                       std::int64_t m,
                       std::int64_t n,
                       std::int64_t k,
@@ -305,9 +305,9 @@ gemm_bias (USM Version)
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event gemm_bias(sycl::queue &queue,
-                             onemkl::transpose transa,
-                             onemkl::transpose transb,
-                             onemkl::offset offset_type,
+                             oneapi::mkl::transpose transa,
+                             oneapi::mkl::transpose transb,
+                             oneapi::mkl::offset offset_type,
                              std::int64_t m,
                              std::int64_t n,
                              std::int64_t k,
@@ -328,9 +328,9 @@ gemm_bias (USM Version)
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event gemm_bias(sycl::queue &queue,
-                             onemkl::transpose transa,
-                             onemkl::transpose transb,
-                             onemkl::offset offset_type,
+                             oneapi::mkl::transpose transa,
+                             oneapi::mkl::transpose transb,
+                             oneapi::mkl::offset offset_type,
                              std::int64_t m,
                              std::int64_t n,
                              std::int64_t k,

--- a/source/elements/oneMKL/source/domains/blas/gemmt.rst
+++ b/source/elements/oneMKL/source/domains/blas/gemmt.rst
@@ -56,9 +56,9 @@ gemmt (Buffer Version)
 
    namespace oneapi::mkl::blas::column_major {
        void gemmt(sycl::queue &queue,
-                  onemkl::uplo upper_lower,
-                  onemkl::transpose transa,
-                  onemkl::transpose transb,
+                  oneapi::mkl::uplo upper_lower,
+                  oneapi::mkl::transpose transa,
+                  oneapi::mkl::transpose transb,
                   std::int64_t n,
                   std::int64_t k,
                   T alpha,
@@ -74,9 +74,9 @@ gemmt (Buffer Version)
 
    namespace oneapi::mkl::blas::row_major {
        void gemmt(sycl::queue &queue,
-                  onemkl::uplo upper_lower,
-                  onemkl::transpose transa,
-                  onemkl::transpose transb,
+                  oneapi::mkl::uplo upper_lower,
+                  oneapi::mkl::transpose transa,
+                  oneapi::mkl::transpose transb,
                   std::int64_t n,
                   std::int64_t k,
                   T alpha,
@@ -254,9 +254,9 @@ gemmt (USM Version)
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event gemmt(sycl::queue &queue,
-                         onemkl::uplo upper_lower,
-                         onemkl::transpose transa,
-                         onemkl::transpose transb,
+                         oneapi::mkl::uplo upper_lower,
+                         oneapi::mkl::transpose transa,
+                         oneapi::mkl::transpose transb,
                          std::int64_t n,
                          std::int64_t k,
                          value_or_pointer<T> alpha,
@@ -273,9 +273,9 @@ gemmt (USM Version)
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event gemmt(sycl::queue &queue,
-                         onemkl::uplo upper_lower,
-                         onemkl::transpose transa,
-                         onemkl::transpose transb,
+                         oneapi::mkl::uplo upper_lower,
+                         oneapi::mkl::transpose transa,
+                         oneapi::mkl::transpose transb,
                          std::int64_t n,
                          std::int64_t k,
                          value_or_pointer<T> alpha,

--- a/source/elements/oneMKL/source/domains/blas/gemv.rst
+++ b/source/elements/oneMKL/source/domains/blas/gemv.rst
@@ -52,7 +52,7 @@ gemv (Buffer Version)
 
    namespace oneapi::mkl::blas::column_major {
        void gemv(sycl::queue &queue,
-                 onemkl::transpose trans,
+                 oneapi::mkl::transpose trans,
                  std::int64_t m,
                  std::int64_t n,
                  T alpha,
@@ -68,7 +68,7 @@ gemv (Buffer Version)
 
    namespace oneapi::mkl::blas::row_major {
        void gemv(sycl::queue &queue,
-                 onemkl::transpose trans,
+                 oneapi::mkl::transpose trans,
                  std::int64_t m,
                  std::int64_t n,
                  T alpha,
@@ -174,7 +174,7 @@ gemv (USM Version)
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event gemv(sycl::queue &queue,
-                        onemkl::transpose trans,
+                        oneapi::mkl::transpose trans,
                         std::int64_t m,
                         std::int64_t n,
                         value_or_pointer<T> alpha,
@@ -191,7 +191,7 @@ gemv (USM Version)
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event gemv(sycl::queue &queue,
-                        onemkl::transpose trans,
+                        oneapi::mkl::transpose trans,
                         std::int64_t m,
                         std::int64_t n,
                         value_or_pointer<T> alpha,

--- a/source/elements/oneMKL/source/domains/blas/gemv_batch.rst
+++ b/source/elements/oneMKL/source/domains/blas/gemv_batch.rst
@@ -68,7 +68,7 @@ parameter.
 
    namespace oneapi::mkl::blas::column_major {
        void gemv_batch(sycl::queue &queue,
-                       onemkl::transpose trans,
+                       oneapi::mkl::transpose trans,
                        std::int64_t m,
                        std::int64_t n,
                        T alpha,
@@ -88,7 +88,7 @@ parameter.
 
    namespace oneapi::mkl::blas::row_major {
        void gemv_batch(sycl::queue &queue,
-                       onemkl::transpose trans,
+                       oneapi::mkl::transpose trans,
                        std::int64_t m,
                        std::int64_t n,
                        T alpha,
@@ -249,7 +249,7 @@ total number of vectors in ``x`` and ``y`` and matrices in ``A`` are given by th
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event gemv_batch(sycl::queue &queue,
-                              const onemkl::transpose *trans,
+                              const oneapi::mkl::transpose *trans,
                               const std::int64_t *m,
                               const std::int64_t *n,
                               const T *alpha,
@@ -268,7 +268,7 @@ total number of vectors in ``x`` and ``y`` and matrices in ``A`` are given by th
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event gemv_batch(sycl::queue &queue,
-                              const onemkl::transpose *trans,
+                              const oneapi::mkl::transpose *trans,
                               const std::int64_t *m,
                               const std::int64_t *n,
                               const T *alpha,
@@ -292,7 +292,7 @@ total number of vectors in ``x`` and ``y`` and matrices in ``A`` are given by th
       The queue where the routine should be executed.
 
    trans
-      Array of ``group_count`` ``onemkl::transpose`` values. ``trans[i]`` specifies the form of op(``A``) used in
+      Array of ``group_count`` ``oneapi::mkl::transpose`` values. ``trans[i]`` specifies the form of op(``A``) used in
       the matrix-vector product in group ``i``. See :ref:`onemkl_datatypes` for more details.
 
    m
@@ -377,7 +377,7 @@ total number of vectors in ``x`` and ``y`` and matrices in ``A`` are given by th
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event gemv_batch(sycl::queue &queue,
-                              onemkl::transpose trans,
+                              oneapi::mkl::transpose trans,
                               std::int64_t m,
                               std::int64_t n,
                               value_or_pointer<T> alpha,
@@ -398,7 +398,7 @@ total number of vectors in ``x`` and ``y`` and matrices in ``A`` are given by th
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event gemv_batch(sycl::queue &queue,
-                              onemkl::transpose trans,
+                              oneapi::mkl::transpose trans,
                               std::int64_t m,
                               std::int64_t n,
                               value_or_pointer<T> alpha,

--- a/source/elements/oneMKL/source/domains/blas/hbmv.rst
+++ b/source/elements/oneMKL/source/domains/blas/hbmv.rst
@@ -50,7 +50,7 @@ hbmv (Buffer Version)
 
    namespace oneapi::mkl::blas::column_major {
        void hbmv(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
+                 oneapi::mkl::uplo upper_lower,
                  std::int64_t n,
                  std::int64_t k,
                  T alpha,
@@ -66,7 +66,7 @@ hbmv (Buffer Version)
 
    namespace oneapi::mkl::blas::row_major {
        void hbmv(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
+                 oneapi::mkl::uplo upper_lower,
                  std::int64_t n,
                  std::int64_t k,
                  T alpha,
@@ -166,7 +166,7 @@ hbmv (USM Version)
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event hbmv(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
+                        oneapi::mkl::uplo upper_lower,
                         std::int64_t n,
                         std::int64_t k,
                         value_or_pointer<T> alpha,
@@ -183,7 +183,7 @@ hbmv (USM Version)
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event hbmv(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
+                        oneapi::mkl::uplo upper_lower,
                         std::int64_t n,
                         std::int64_t k,
                         value_or_pointer<T> alpha,

--- a/source/elements/oneMKL/source/domains/blas/hemm.rst
+++ b/source/elements/oneMKL/source/domains/blas/hemm.rst
@@ -61,8 +61,8 @@ hemm (Buffer Version)
 
    namespace oneapi::mkl::blas::column_major {
        void hemm(sycl::queue &queue,
-                 onemkl::side left_right,
-                 onemkl::uplo upper_lower,
+                 oneapi::mkl::side left_right,
+                 oneapi::mkl::uplo upper_lower,
                  std::int64_t m,
                  std::int64_t n,
                  T alpha,
@@ -78,8 +78,8 @@ hemm (Buffer Version)
 
    namespace oneapi::mkl::blas::row_major {
        void hemm(sycl::queue &queue,
-                 onemkl::side left_right,
-                 onemkl::uplo upper_lower,
+                 oneapi::mkl::side left_right,
+                 oneapi::mkl::uplo upper_lower,
                  std::int64_t m,
                  std::int64_t n,
                  T alpha,
@@ -206,8 +206,8 @@ hemm (USM Version)
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event hemm(sycl::queue &queue,
-                        onemkl::side left_right,
-                        onemkl::uplo upper_lower,
+                        oneapi::mkl::side left_right,
+                        oneapi::mkl::uplo upper_lower,
                         std::int64_t m,
                         std::int64_t n,
                         value_or_pointer<T> alpha,
@@ -224,8 +224,8 @@ hemm (USM Version)
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event hemm(sycl::queue &queue,
-                        onemkl::side left_right,
-                        onemkl::uplo upper_lower,
+                        oneapi::mkl::side left_right,
+                        oneapi::mkl::uplo upper_lower,
                         std::int64_t m,
                         std::int64_t n,
                         value_or_pointer<T> alpha,

--- a/source/elements/oneMKL/source/domains/blas/hemv.rst
+++ b/source/elements/oneMKL/source/domains/blas/hemv.rst
@@ -49,7 +49,7 @@ hemv (Buffer Version)
 
    namespace oneapi::mkl::blas::column_major {
        void hemv(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
+                 oneapi::mkl::uplo upper_lower,
                  std::int64_t n,
                  T alpha,
                  sycl::buffer<T,1> &a,
@@ -64,7 +64,7 @@ hemv (Buffer Version)
 
    namespace oneapi::mkl::blas::row_major {
        void hemv(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
+                 oneapi::mkl::uplo upper_lower,
                  std::int64_t n,
                  T alpha,
                  sycl::buffer<T,1> &a,
@@ -159,7 +159,7 @@ hemv (USM Version)
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event hemv(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
+                        oneapi::mkl::uplo upper_lower,
                         std::int64_t n,
                         value_or_pointer<T> alpha,
                         const T *a,
@@ -175,7 +175,7 @@ hemv (USM Version)
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event hemv(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
+                        oneapi::mkl::uplo upper_lower,
                         std::int64_t n,
                         value_or_pointer<T> alpha,
                         const T *a,

--- a/source/elements/oneMKL/source/domains/blas/her.rst
+++ b/source/elements/oneMKL/source/domains/blas/her.rst
@@ -51,7 +51,7 @@ her (Buffer Version)
 
    namespace oneapi::mkl::blas::column_major {
        void her(sycl::queue &queue,
-                onemkl::uplo upper_lower,
+                oneapi::mkl::uplo upper_lower,
                 std::int64_t n,
                 Treal alpha,
                 sycl::buffer<T,1> &x,
@@ -63,7 +63,7 @@ her (Buffer Version)
 
    namespace oneapi::mkl::blas::row_major {
        void her(sycl::queue &queue,
-                onemkl::uplo upper_lower,
+                oneapi::mkl::uplo upper_lower,
                 std::int64_t n,
                 Treal alpha,
                 sycl::buffer<T,1> &x,
@@ -149,7 +149,7 @@ her (USM Version)
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event her(sycl::queue &queue,
-                       onemkl::uplo upper_lower,
+                       oneapi::mkl::uplo upper_lower,
                        std::int64_t n,
                        value_or_pointer<Treal> alpha,
                        const T *x,
@@ -162,7 +162,7 @@ her (USM Version)
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event her(sycl::queue &queue,
-                       onemkl::uplo upper_lower,
+                       oneapi::mkl::uplo upper_lower,
                        std::int64_t n,
                        value_or_pointer<Treal> alpha,
                        const T *x,

--- a/source/elements/oneMKL/source/domains/blas/her2.rst
+++ b/source/elements/oneMKL/source/domains/blas/her2.rst
@@ -48,7 +48,7 @@ her2 (Buffer Version)
 
    namespace oneapi::mkl::blas::column_major {
        void her2(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
+                 oneapi::mkl::uplo upper_lower,
                  std::int64_t n,
                  T alpha,
                  sycl::buffer<T,1> &x,
@@ -62,7 +62,7 @@ her2 (Buffer Version)
 
    namespace oneapi::mkl::blas::row_major {
        void her2(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
+                 oneapi::mkl::uplo upper_lower,
                  std::int64_t n,
                  T alpha,
                  sycl::buffer<T,1> &x,
@@ -158,7 +158,7 @@ her2 (USM Version)
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event her2(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
+                        oneapi::mkl::uplo upper_lower,
                         std::int64_t n,
                         value_or_pointer<T> alpha,
                         const T *x,
@@ -173,7 +173,7 @@ her2 (USM Version)
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event her2(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
+                        oneapi::mkl::uplo upper_lower,
                         std::int64_t n,
                         value_or_pointer<T> alpha,
                         const T *x,

--- a/source/elements/oneMKL/source/domains/blas/her2k.rst
+++ b/source/elements/oneMKL/source/domains/blas/her2k.rst
@@ -63,8 +63,8 @@ her2k (Buffer Version)
 
    namespace oneapi::mkl::blas::column_major {
        void her2k(sycl::queue &queue,
-                  onemkl::uplo upper_lower,
-                  onemkl::transpose trans,
+                  oneapi::mkl::uplo upper_lower,
+                  oneapi::mkl::transpose trans,
                   std::int64_t n,
                   std::int64_t k,
                   T alpha,
@@ -80,8 +80,8 @@ her2k (Buffer Version)
 
    namespace oneapi::mkl::blas::row_major {
        void her2k(sycl::queue &queue,
-                  onemkl::uplo upper_lower,
-                  onemkl::transpose trans,
+                  oneapi::mkl::uplo upper_lower,
+                  oneapi::mkl::transpose trans,
                   std::int64_t n,
                   std::int64_t k,
                   T alpha,
@@ -249,8 +249,8 @@ her2k (USM Version)
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event her2k(sycl::queue &queue,
-                         onemkl::uplo upper_lower,
-                         onemkl::transpose trans,
+                         oneapi::mkl::uplo upper_lower,
+                         oneapi::mkl::transpose trans,
                          std::int64_t n,
                          std::int64_t k,
                          value_or_pointer<T> alpha,
@@ -267,8 +267,8 @@ her2k (USM Version)
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event her2k(sycl::queue &queue,
-                         onemkl::uplo upper_lower,
-                         onemkl::transpose trans,
+                         oneapi::mkl::uplo upper_lower,
+                         oneapi::mkl::transpose trans,
                          std::int64_t n,
                          std::int64_t k,
                          value_or_pointer<T> alpha,

--- a/source/elements/oneMKL/source/domains/blas/herk.rst
+++ b/source/elements/oneMKL/source/domains/blas/herk.rst
@@ -53,8 +53,8 @@ herk (Buffer Version)
 
    namespace oneapi::mkl::blas::column_major {
        void herk(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
-                 onemkl::transpose trans,
+                 oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose trans,
                  std::int64_t n,
                  std::int64_t k,
                  Treal alpha,
@@ -68,8 +68,8 @@ herk (Buffer Version)
 
    namespace oneapi::mkl::blas::row_major {
        void herk(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
-                 onemkl::transpose trans,
+                 oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose trans,
                  std::int64_t n,
                  std::int64_t k,
                  Treal alpha,
@@ -200,8 +200,8 @@ herk (USM Version)
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event herk(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
-                        onemkl::transpose trans,
+                        oneapi::mkl::uplo upper_lower,
+                        oneapi::mkl::transpose trans,
                         std::int64_t n,
                         std::int64_t k,
                         value_or_pointer<Treal> alpha,
@@ -216,8 +216,8 @@ herk (USM Version)
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event herk(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
-                        onemkl::transpose trans,
+                        oneapi::mkl::uplo upper_lower,
+                        oneapi::mkl::transpose trans,
                         std::int64_t n,
                         std::int64_t k,
                         value_or_pointer<Treal> alpha,

--- a/source/elements/oneMKL/source/domains/blas/hpmv.rst
+++ b/source/elements/oneMKL/source/domains/blas/hpmv.rst
@@ -49,7 +49,7 @@ hpmv (Buffer Version)
 
    namespace oneapi::mkl::blas::column_major {
        void hpmv(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
+                 oneapi::mkl::uplo upper_lower,
                  std::int64_t n,
                  T alpha,
                  sycl::buffer<T,1> &a,
@@ -63,7 +63,7 @@ hpmv (Buffer Version)
 
    namespace oneapi::mkl::blas::row_major {
        void hpmv(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
+                 oneapi::mkl::uplo upper_lower,
                  std::int64_t n,
                  T alpha,
                  sycl::buffer<T,1> &a,
@@ -156,7 +156,7 @@ hpmv (USM Version)
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event hpmv(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
+                        oneapi::mkl::uplo upper_lower,
                         std::int64_t n,
                         value_or_pointer<T> alpha,
                         const T *a,
@@ -171,7 +171,7 @@ hpmv (USM Version)
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event hpmv(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
+                        oneapi::mkl::uplo upper_lower,
                         std::int64_t n,
                         value_or_pointer<T> alpha,
                         const T *a,

--- a/source/elements/oneMKL/source/domains/blas/hpr.rst
+++ b/source/elements/oneMKL/source/domains/blas/hpr.rst
@@ -51,7 +51,7 @@ hpr (Buffer Version)
 
    namespace oneapi::mkl::blas::column_major {
        void hpr(sycl::queue &queue,
-                onemkl::uplo upper_lower,
+                oneapi::mkl::uplo upper_lower,
                 std::int64_t n,
                 Treal alpha,
                 sycl::buffer<T,1> &x,
@@ -62,7 +62,7 @@ hpr (Buffer Version)
 
    namespace oneapi::mkl::blas::row_major {
        void hpr(sycl::queue &queue,
-                onemkl::uplo upper_lower,
+                oneapi::mkl::uplo upper_lower,
                 std::int64_t n,
                 Treal alpha,
                 sycl::buffer<T,1> &x,
@@ -146,7 +146,7 @@ hpr (USM Version)
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event hpr(sycl::queue &queue,
-                       onemkl::uplo upper_lower,
+                       oneapi::mkl::uplo upper_lower,
                        std::int64_t n,
                        value_or_pointer<Treal> alpha,
                        const T *x,
@@ -158,7 +158,7 @@ hpr (USM Version)
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event hpr(sycl::queue &queue,
-                       onemkl::uplo upper_lower,
+                       oneapi::mkl::uplo upper_lower,
                        std::int64_t n,
                        value_or_pointer<Treal> alpha,
                        const T *x,

--- a/source/elements/oneMKL/source/domains/blas/hpr2.rst
+++ b/source/elements/oneMKL/source/domains/blas/hpr2.rst
@@ -48,7 +48,7 @@ hpr2 (Buffer Version)
 
    namespace oneapi::mkl::blas::column_major {
        void hpr2(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
+                 oneapi::mkl::uplo upper_lower,
                  std::int64_t n,
                  T alpha,
                  sycl::buffer<T,1> &x,
@@ -61,7 +61,7 @@ hpr2 (Buffer Version)
 
    namespace oneapi::mkl::blas::row_major {
        void hpr2(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
+                 oneapi::mkl::uplo upper_lower,
                  std::int64_t n,
                  T alpha,
                  sycl::buffer<T,1> &x,
@@ -155,7 +155,7 @@ hpr2 (USM Version)
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event hpr2(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
+                        oneapi::mkl::uplo upper_lower,
                         std::int64_t n,
                         value_or_pointer<T> alpha,
                         const T *x,
@@ -169,7 +169,7 @@ hpr2 (USM Version)
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event hpr2(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
+                        oneapi::mkl::uplo upper_lower,
                         std::int64_t n,
                         value_or_pointer<T> alpha,
                         const T *x,

--- a/source/elements/oneMKL/source/domains/blas/sbmv.rst
+++ b/source/elements/oneMKL/source/domains/blas/sbmv.rst
@@ -50,7 +50,7 @@ sbmv (Buffer Version)
 
    namespace oneapi::mkl::blas::column_major {
        void sbmv(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
+                 oneapi::mkl::uplo upper_lower,
                  std::int64_t n,
                  std::int64_t k,
                  T alpha,
@@ -66,7 +66,7 @@ sbmv (Buffer Version)
 
    namespace oneapi::mkl::blas::row_major {
        void sbmv(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
+                 oneapi::mkl::uplo upper_lower,
                  std::int64_t n,
                  std::int64_t k,
                  T alpha,
@@ -166,7 +166,7 @@ sbmv (USM Version)
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event sbmv(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
+                        oneapi::mkl::uplo upper_lower,
                         std::int64_t n,
                         std::int64_t k,
                         value_or_pointer<T> alpha,
@@ -183,7 +183,7 @@ sbmv (USM Version)
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event sbmv(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
+                        oneapi::mkl::uplo upper_lower,
                         std::int64_t n,
                         std::int64_t k,
                         value_or_pointer<T> alpha,

--- a/source/elements/oneMKL/source/domains/blas/spmv.rst
+++ b/source/elements/oneMKL/source/domains/blas/spmv.rst
@@ -49,7 +49,7 @@ spmv (Buffer Version)
 
    namespace oneapi::mkl::blas::column_major {
        void spmv(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
+                 oneapi::mkl::uplo upper_lower,
                  std::int64_t n,
                  T alpha,
                  sycl::buffer<T,1> &a,
@@ -63,7 +63,7 @@ spmv (Buffer Version)
 
    namespace oneapi::mkl::blas::row_major {
        void spmv(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
+                 oneapi::mkl::uplo upper_lower,
                  std::int64_t n,
                  T alpha,
                  sycl::buffer<T,1> &a,
@@ -153,7 +153,7 @@ spmv (USM Version)
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event spmv(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
+                        oneapi::mkl::uplo upper_lower,
                         std::int64_t n,
                         value_or_pointer<T> alpha,
                         const T *a,
@@ -168,7 +168,7 @@ spmv (USM Version)
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event spmv(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
+                        oneapi::mkl::uplo upper_lower,
                         std::int64_t n,
                         value_or_pointer<T> alpha,
                         const T *a,

--- a/source/elements/oneMKL/source/domains/blas/spr.rst
+++ b/source/elements/oneMKL/source/domains/blas/spr.rst
@@ -48,7 +48,7 @@ spr (Buffer Version)
 
    namespace oneapi::mkl::blas::column_major {
        void spr(sycl::queue &queue,
-                onemkl::uplo upper_lower,
+                oneapi::mkl::uplo upper_lower,
                 std::std::int64_t n,
                 T alpha,
                 sycl::buffer<T,1> &x,
@@ -59,7 +59,7 @@ spr (Buffer Version)
 
    namespace oneapi::mkl::blas::row_major {
        void spr(sycl::queue &queue,
-                onemkl::uplo upper_lower,
+                oneapi::mkl::uplo upper_lower,
                 std::std::int64_t n,
                 T alpha,
                 sycl::buffer<T,1> &x,
@@ -139,7 +139,7 @@ spr (USM Version)
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event spr(sycl::queue &queue,
-                       onemkl::uplo upper_lower,
+                       oneapi::mkl::uplo upper_lower,
                        std::int64_t n,
                        value_or_pointer<T> alpha,
                        const T *x,
@@ -151,7 +151,7 @@ spr (USM Version)
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event spr(sycl::queue &queue,
-                       onemkl::uplo upper_lower,
+                       oneapi::mkl::uplo upper_lower,
                        std::int64_t n,
                        value_or_pointer<T> alpha,
                        const T *x,

--- a/source/elements/oneMKL/source/domains/blas/spr2.rst
+++ b/source/elements/oneMKL/source/domains/blas/spr2.rst
@@ -48,7 +48,7 @@ spr2 (Buffer Version)
 
    namespace oneapi::mkl::blas::column_major {
        void spr2(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
+                 oneapi::mkl::uplo upper_lower,
                  std::int64_t n,
                  T alpha,
                  sycl::buffer<T,1> &x,
@@ -61,7 +61,7 @@ spr2 (Buffer Version)
 
    namespace oneapi::mkl::blas::row_major {
        void spr2(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
+                 oneapi::mkl::uplo upper_lower,
                  std::int64_t n,
                  T alpha,
                  sycl::buffer<T,1> &x,
@@ -150,7 +150,7 @@ spr2 (USM Version)
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event spr2(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
+                        oneapi::mkl::uplo upper_lower,
                         std::int64_t n,
                         value_or_pointer<T> alpha,
                         const T *x,
@@ -164,7 +164,7 @@ spr2 (USM Version)
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event spr2(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
+                        oneapi::mkl::uplo upper_lower,
                         std::int64_t n,
                         value_or_pointer<T> alpha,
                         const T *x,

--- a/source/elements/oneMKL/source/domains/blas/symm.rst
+++ b/source/elements/oneMKL/source/domains/blas/symm.rst
@@ -62,8 +62,8 @@ symm (Buffer Version)
 
    namespace oneapi::mkl::blas::column_major {
        void symm(sycl::queue &queue,
-                 onemkl::side left_right,
-                 onemkl::uplo upper_lower,
+                 oneapi::mkl::side left_right,
+                 oneapi::mkl::uplo upper_lower,
                  std::int64_t m,
                  std::int64_t n,
                  T alpha,
@@ -79,8 +79,8 @@ symm (Buffer Version)
 
    namespace oneapi::mkl::blas::row_major {
        void symm(sycl::queue &queue,
-                 onemkl::side left_right,
-                 onemkl::uplo upper_lower,
+                 oneapi::mkl::side left_right,
+                 oneapi::mkl::uplo upper_lower,
                  std::int64_t m,
                  std::int64_t n,
                  T alpha,
@@ -205,8 +205,8 @@ symm (USM Version)
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event symm(sycl::queue &queue,
-                        onemkl::side left_right,
-                        onemkl::uplo upper_lower,
+                        oneapi::mkl::side left_right,
+                        oneapi::mkl::uplo upper_lower,
                         std::int64_t m,
                         std::int64_t n,
                         value_or_pointer<T> alpha,
@@ -223,8 +223,8 @@ symm (USM Version)
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event symm(sycl::queue &queue,
-                        onemkl::side left_right,
-                        onemkl::uplo upper_lower,
+                        oneapi::mkl::side left_right,
+                        oneapi::mkl::uplo upper_lower,
                         std::int64_t m,
                         std::int64_t n,
                         value_or_pointer<T> alpha,

--- a/source/elements/oneMKL/source/domains/blas/symv.rst
+++ b/source/elements/oneMKL/source/domains/blas/symv.rst
@@ -51,7 +51,7 @@ symv (Buffer Version)
 
    namespace oneapi::mkl::blas::column_major {
        void symv(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
+                 oneapi::mkl::uplo upper_lower,
                  std::int64_t n,
                  T alpha,
                  sycl::buffer<T,1> &a,
@@ -66,7 +66,7 @@ symv (Buffer Version)
 
    namespace oneapi::mkl::blas::row_major {
        void symv(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
+                 oneapi::mkl::uplo upper_lower,
                  std::int64_t n,
                  T alpha,
                  sycl::buffer<T,1> &a,
@@ -161,7 +161,7 @@ symv (USM Version)
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event symv(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
+                        oneapi::mkl::uplo upper_lower,
                         std::int64_t n,
                         value_or_pointer<T> alpha,
                         const T *a,
@@ -177,7 +177,7 @@ symv (USM Version)
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event symv(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
+                        oneapi::mkl::uplo upper_lower,
                         std::int64_t n,
                         value_or_pointer<T> alpha,
                         const T *a,

--- a/source/elements/oneMKL/source/domains/blas/syr.rst
+++ b/source/elements/oneMKL/source/domains/blas/syr.rst
@@ -51,7 +51,7 @@ syr (Buffer Version)
 
    namespace oneapi::mkl::blas::column_major {
        void syr(sycl::queue &queue,
-                onemkl::uplo upper_lower,
+                oneapi::mkl::uplo upper_lower,
                 std::int64_t n,
                 T alpha,
                 sycl::buffer<T,1> &x,
@@ -63,7 +63,7 @@ syr (Buffer Version)
 
    namespace oneapi::mkl::blas::row_major {
        void syr(sycl::queue &queue,
-                onemkl::uplo upper_lower,
+                oneapi::mkl::uplo upper_lower,
                 std::int64_t n,
                 T alpha,
                 sycl::buffer<T,1> &x,
@@ -147,7 +147,7 @@ syr (USM Version)
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event syr(sycl::queue &queue,
-                       onemkl::uplo upper_lower,
+                       oneapi::mkl::uplo upper_lower,
                        std::int64_t n,
                        value_or_pointer<T> alpha,
                        const T *x,
@@ -160,7 +160,7 @@ syr (USM Version)
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event syr(sycl::queue &queue,
-                       onemkl::uplo upper_lower,
+                       oneapi::mkl::uplo upper_lower,
                        std::int64_t n,
                        value_or_pointer<T> alpha,
                        const T *x,

--- a/source/elements/oneMKL/source/domains/blas/syr2.rst
+++ b/source/elements/oneMKL/source/domains/blas/syr2.rst
@@ -51,7 +51,7 @@ syr2 (Buffer Version)
 
    namespace oneapi::mkl::blas::column_major {
        void syr2(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
+                 oneapi::mkl::uplo upper_lower,
                  std::int64_t n,
                  T alpha,
                  sycl::buffer<T,1> &x,
@@ -65,7 +65,7 @@ syr2 (Buffer Version)
 
    namespace oneapi::mkl::blas::row_major {
        void syr2(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
+                 oneapi::mkl::uplo upper_lower,
                  std::int64_t n,
                  T alpha,
                  sycl::buffer<T,1> &x,
@@ -159,7 +159,7 @@ syr2 (USM Version)
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event syr2(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
+                        oneapi::mkl::uplo upper_lower,
                         std::int64_t n,
                         value_or_pointer<T> alpha,
                         const T *x,
@@ -174,7 +174,7 @@ syr2 (USM Version)
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event syr2(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
+                        oneapi::mkl::uplo upper_lower,
                         std::int64_t n,
                         value_or_pointer<T> alpha,
                         const T *x,

--- a/source/elements/oneMKL/source/domains/blas/syr2k.rst
+++ b/source/elements/oneMKL/source/domains/blas/syr2k.rst
@@ -64,8 +64,8 @@ syr2k (Buffer Version)
 
    namespace oneapi::mkl::blas::column_major {
        void syr2k(sycl::queue &queue,
-                  onemkl::uplo upper_lower,
-                  onemkl::transpose trans,
+                  oneapi::mkl::uplo upper_lower,
+                  oneapi::mkl::transpose trans,
                   std::int64_t n,
                   std::int64_t k,
                   T alpha,
@@ -81,8 +81,8 @@ syr2k (Buffer Version)
 
    namespace oneapi::mkl::blas::row_major {
        void syr2k(sycl::queue &queue,
-                  onemkl::uplo upper_lower,
-                  onemkl::transpose trans,
+                  oneapi::mkl::uplo upper_lower,
+                  oneapi::mkl::transpose trans,
                   std::int64_t n,
                   std::int64_t k,
                   T alpha,
@@ -249,8 +249,8 @@ syr2k (USM Version)
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event syr2k(sycl::queue &queue,
-                         onemkl::uplo upper_lower,
-                         onemkl::transpose trans,
+                         oneapi::mkl::uplo upper_lower,
+                         oneapi::mkl::transpose trans,
                          std::int64_t n,
                          std::int64_t k,
                          value_or_pointer<T> alpha,
@@ -267,8 +267,8 @@ syr2k (USM Version)
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event syr2k(sycl::queue &queue,
-                         onemkl::uplo upper_lower,
-                         onemkl::transpose trans,
+                         oneapi::mkl::uplo upper_lower,
+                         oneapi::mkl::transpose trans,
                          std::int64_t n,
                          std::int64_t k,
                          value_or_pointer<T> alpha,

--- a/source/elements/oneMKL/source/domains/blas/syrk.rst
+++ b/source/elements/oneMKL/source/domains/blas/syrk.rst
@@ -53,8 +53,8 @@ syrk (Buffer Version)
 
    namespace oneapi::mkl::blas::column_major {
        void syrk(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
-                 onemkl::transpose trans,
+                 oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose trans,
                  std::int64_t n,
                  std::int64_t k,
                  T alpha,
@@ -68,8 +68,8 @@ syrk (Buffer Version)
 
    namespace oneapi::mkl::blas::row_major {
        void syrk(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
-                 onemkl::transpose trans,
+                 oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose trans,
                  std::int64_t n,
                  std::int64_t k,
                  T alpha,
@@ -195,8 +195,8 @@ syrk (USM Version)
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event syrk(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
-                        onemkl::transpose trans,
+                        oneapi::mkl::uplo upper_lower,
+                        oneapi::mkl::transpose trans,
                         std::int64_t n,
                         std::int64_t k,
                         value_or_pointer<T> alpha,
@@ -211,8 +211,8 @@ syrk (USM Version)
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event syrk(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
-                        onemkl::transpose trans,
+                        oneapi::mkl::uplo upper_lower,
+                        oneapi::mkl::transpose trans,
                         std::int64_t n,
                         std::int64_t k,
                         value_or_pointer<T> alpha,

--- a/source/elements/oneMKL/source/domains/blas/syrk_batch.rst
+++ b/source/elements/oneMKL/source/domains/blas/syrk_batch.rst
@@ -67,8 +67,8 @@ of matrices in ``a`` and ``c`` buffers is given by the ``batch_size`` parameter.
 
    namespace oneapi::mkl::blas::column_major {
        void syrk_batch(sycl::queue &queue,
-                       onemkl::uplo upper_lower,
-                       onemkl::transpose trans,
+                       oneapi::mkl::uplo upper_lower,
+                       oneapi::mkl::transpose trans,
                        std::int64_t n,
                        std::int64_t k,
                        T alpha,
@@ -85,8 +85,8 @@ of matrices in ``a`` and ``c`` buffers is given by the ``batch_size`` parameter.
 
    namespace oneapi::mkl::blas::row_major {
        void syrk_batch(sycl::queue &queue,
-                       onemkl::uplo upper_lower,
-                       onemkl::transpose trans,
+                       oneapi::mkl::uplo upper_lower,
+                       oneapi::mkl::transpose trans,
                        std::int64_t n,
                        std::int64_t k,
                        T alpha,
@@ -295,12 +295,12 @@ in ``a`` and ``c`` are given by the ``batch_size`` parameter.
       The queue where the routine should be executed.
 
    upper_lower
-      Array of ``group_count`` ``onemkl::upper_lower``
+      Array of ``group_count`` ``oneapi::mkl::upper_lower``
       values. ``upper_lower[i]`` specifies whether data in C for every
       matrix in group ``i`` is in upper or lower triangle.
 
    trans
-      Array of ``group_count`` ``onemkl::transpose`` values. ``trans[i]`` specifies the form of op(``A``) used in
+      Array of ``group_count`` ``oneapi::mkl::transpose`` values. ``trans[i]`` specifies the form of op(``A``) used in
       the rank-k update in group ``i``. See :ref:`onemkl_datatypes` for more details.
 
    n

--- a/source/elements/oneMKL/source/domains/blas/tbmv.rst
+++ b/source/elements/oneMKL/source/domains/blas/tbmv.rst
@@ -52,9 +52,9 @@ tbmv (Buffer Version)
 
    namespace oneapi::mkl::blas::column_major {
        void tbmv(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
-                 onemkl::transpose trans,
-                 onemkl::diag unit_nonunit,
+                 oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_nonunit,
                  std::int64_t n,
                  std::int64_t k,
                  sycl::buffer<T,1> &a,
@@ -66,9 +66,9 @@ tbmv (Buffer Version)
 
    namespace oneapi::mkl::blas::row_major {
        void tbmv(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
-                 onemkl::transpose trans,
-                 onemkl::diag unit_nonunit,
+                 oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_nonunit,
                  std::int64_t n,
                  std::int64_t k,
                  sycl::buffer<T,1> &a,
@@ -156,9 +156,9 @@ tbmv (USM Version)
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event tbmv(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
-                        onemkl::transpose trans,
-                        onemkl::diag unit_nonunit,
+                        oneapi::mkl::uplo upper_lower,
+                        oneapi::mkl::transpose trans,
+                        oneapi::mkl::diag unit_nonunit,
                         std::int64_t n,
                         std::int64_t k,
                         const T *a,
@@ -171,9 +171,9 @@ tbmv (USM Version)
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event tbmv(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
-                        onemkl::transpose trans,
-                        onemkl::diag unit_nonunit,
+                        oneapi::mkl::uplo upper_lower,
+                        oneapi::mkl::transpose trans,
+                        oneapi::mkl::diag unit_nonunit,
                         std::int64_t n,
                         std::int64_t k,
                         const T *a,

--- a/source/elements/oneMKL/source/domains/blas/tbsv.rst
+++ b/source/elements/oneMKL/source/domains/blas/tbsv.rst
@@ -54,9 +54,9 @@ tbsv (Buffer Version)
 
    namespace oneapi::mkl::blas::column_major {
        void tbsv(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
-                 onemkl::transpose trans,
-                 onemkl::diag unit_nonunit,
+                 oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_nonunit,
                  std::int64_t n,
                  std::int64_t k,
                  sycl::buffer<T,1> &a,
@@ -68,9 +68,9 @@ tbsv (Buffer Version)
 
    namespace oneapi::mkl::blas::row_major {
        void tbsv(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
-                 onemkl::transpose trans,
-                 onemkl::diag unit_nonunit,
+                 oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_nonunit,
                  std::int64_t n,
                  std::int64_t k,
                  sycl::buffer<T,1> &a,
@@ -158,9 +158,9 @@ tbsv (USM Version)
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event tbsv(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
-                        onemkl::transpose trans,
-                        onemkl::diag unit_nonunit,
+                        oneapi::mkl::uplo upper_lower,
+                        oneapi::mkl::transpose trans,
+                        oneapi::mkl::diag unit_nonunit,
                         std::int64_t n,
                         std::int64_t k,
                         const T *a,
@@ -173,9 +173,9 @@ tbsv (USM Version)
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event tbsv(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
-                        onemkl::transpose trans,
-                        onemkl::diag unit_nonunit,
+                        oneapi::mkl::uplo upper_lower,
+                        oneapi::mkl::transpose trans,
+                        oneapi::mkl::diag unit_nonunit,
                         std::int64_t n,
                         std::int64_t k,
                         const T *a,

--- a/source/elements/oneMKL/source/domains/blas/tpmv.rst
+++ b/source/elements/oneMKL/source/domains/blas/tpmv.rst
@@ -52,9 +52,9 @@ tpmv (Buffer Version)
 
    namespace oneapi::mkl::blas::column_major {
        void tpmv(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
-                 onemkl::transpose trans,
-                 onemkl::diag unit_nonunit,
+                 oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_nonunit,
                  std::int64_t n,
                  sycl::buffer<T,1> &a,
                  sycl::buffer<T,1> &x,
@@ -64,9 +64,9 @@ tpmv (Buffer Version)
 
    namespace oneapi::mkl::blas::row_major {
        void tpmv(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
-                 onemkl::transpose trans,
-                 onemkl::diag unit_nonunit,
+                 oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_nonunit,
                  std::int64_t n,
                  sycl::buffer<T,1> &a,
                  sycl::buffer<T,1> &x,
@@ -144,9 +144,9 @@ tpmv (USM Version)
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event tpmv(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
-                        onemkl::transpose trans,
-                        onemkl::diag unit_nonunit,
+                        oneapi::mkl::uplo upper_lower,
+                        oneapi::mkl::transpose trans,
+                        oneapi::mkl::diag unit_nonunit,
                         std::int64_t n,
                         const T *a,
                         T *x,
@@ -157,9 +157,9 @@ tpmv (USM Version)
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event tpmv(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
-                        onemkl::transpose trans,
-                        onemkl::diag unit_nonunit,
+                        oneapi::mkl::uplo upper_lower,
+                        oneapi::mkl::transpose trans,
+                        oneapi::mkl::diag unit_nonunit,
                         std::int64_t n,
                         const T *a,
                         T *x,

--- a/source/elements/oneMKL/source/domains/blas/tpsv.rst
+++ b/source/elements/oneMKL/source/domains/blas/tpsv.rst
@@ -54,9 +54,9 @@ tpsv (Buffer Version)
 
    namespace oneapi::mkl::blas::column_major {
        void tpsv(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
-                 onemkl::transpose trans,
-                 onemkl::diag unit_nonunit,
+                 oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_nonunit,
                  std::int64_t n,
                  std::int64_t k,
                  sycl::buffer<T,1> &a,
@@ -67,9 +67,9 @@ tpsv (Buffer Version)
 
    namespace oneapi::mkl::blas::row_major {
        void tpsv(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
-                 onemkl::transpose trans,
-                 onemkl::diag unit_nonunit,
+                 oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_nonunit,
                  std::int64_t n,
                  std::int64_t k,
                  sycl::buffer<T,1> &a,
@@ -149,9 +149,9 @@ tpsv (USM Version)
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event tpsv(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
-                        onemkl::transpose trans,
-                        onemkl::diag unit_nonunit,
+                        oneapi::mkl::uplo upper_lower,
+                        oneapi::mkl::transpose trans,
+                        oneapi::mkl::diag unit_nonunit,
                         std::int64_t n,
                         std::int64_t k,
                         const T *a,
@@ -163,9 +163,9 @@ tpsv (USM Version)
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event tpsv(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
-                        onemkl::transpose trans,
-                        onemkl::diag unit_nonunit,
+                        oneapi::mkl::uplo upper_lower,
+                        oneapi::mkl::transpose trans,
+                        oneapi::mkl::diag unit_nonunit,
                         std::int64_t n,
                         std::int64_t k,
                         const T *a,

--- a/source/elements/oneMKL/source/domains/blas/trmm.rst
+++ b/source/elements/oneMKL/source/domains/blas/trmm.rst
@@ -82,10 +82,10 @@ trmm (Buffer Version)
 
    namespace oneapi::mkl::blas::column_major {
        void trmm(sycl::queue &queue,
-                 onemkl::side left_right,
-                 onemkl::uplo upper_lower,
-                 onemkl::transpose transa,
-                 onemkl::diag unit_diag,
+                 oneapi::mkl::side left_right,
+                 oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose transa,
+                 oneapi::mkl::diag unit_diag,
                  std::int64_t m,
                  std::int64_t n,
                  T alpha,
@@ -98,10 +98,10 @@ trmm (Buffer Version)
 
    namespace oneapi::mkl::blas::row_major {
        void trmm(sycl::queue &queue,
-                 onemkl::side left_right,
-                 onemkl::uplo upper_lower,
-                 onemkl::transpose transa,
-                 onemkl::diag unit_diag,
+                 oneapi::mkl::side left_right,
+                 oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose transa,
+                 oneapi::mkl::diag unit_diag,
                  std::int64_t m,
                  std::int64_t n,
                  T alpha,
@@ -210,10 +210,10 @@ trmm (Buffer Version)
 
    namespace oneapi::mkl::blas::column_major {
        void trmm(sycl::queue &queue,
-                 onemkl::side left_right,
-                 onemkl::uplo upper_lower,
-                 onemkl::transpose trans,
-                 onemkl::diag unit_diag,
+                 oneapi::mkl::side left_right,
+                 oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_diag,
                  std::int64_t m,
                  std::int64_t n,
                  T alpha,
@@ -230,10 +230,10 @@ trmm (Buffer Version)
 
    namespace oneapi::mkl::blas::row_major {
        void trmm(sycl::queue &queue,
-                 onemkl::side left_right,
-                 onemkl::uplo upper_lower,
-                 onemkl::transpose trans,
-                 onemkl::diag unit_diag,
+                 oneapi::mkl::side left_right,
+                 oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_diag,
                  std::int64_t m,
                  std::int64_t n,
                  T alpha,
@@ -342,10 +342,10 @@ trmm (USM Version)
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event trmm(sycl::queue &queue,
-                        onemkl::side left_right,
-                        onemkl::uplo upper_lower,
-                        onemkl::transpose transa,
-                        onemkl::diag unit_diag,
+                        oneapi::mkl::side left_right,
+                        oneapi::mkl::uplo upper_lower,
+                        oneapi::mkl::transpose transa,
+                        oneapi::mkl::diag unit_diag,
                         std::int64_t m,
                         std::int64_t n,
                         value_or_pointer<T> alpha,
@@ -359,10 +359,10 @@ trmm (USM Version)
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event trmm(sycl::queue &queue,
-                        onemkl::side left_right,
-                        onemkl::uplo upper_lower,
-                        onemkl::transpose transa,
-                        onemkl::diag unit_diag,
+                        oneapi::mkl::side left_right,
+                        oneapi::mkl::uplo upper_lower,
+                        oneapi::mkl::transpose transa,
+                        oneapi::mkl::diag unit_diag,
                         std::int64_t m,
                         std::int64_t n,
                         value_or_pointer<T> alpha,
@@ -487,10 +487,10 @@ trmm (USM Version)
 
    namespace oneapi::mkl::blas::column_major {
        void trmm(sycl::queue &queue,
-                 onemkl::side left_right,
-                 onemkl::uplo upper_lower,
-                 onemkl::transpose trans,
-                 onemkl::diag unit_diag,
+                 oneapi::mkl::side left_right,
+                 oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_diag,
                  std::int64_t m,
                  std::int64_t n,
                  value_or_pointer<T> alpha,
@@ -508,10 +508,10 @@ trmm (USM Version)
 
    namespace oneapi::mkl::blas::row_major {
        void trmm(sycl::queue &queue,
-                 onemkl::side left_right,
-                 onemkl::uplo upper_lower,
-                 onemkl::transpose trans,
-                 onemkl::diag unit_diag,
+                 oneapi::mkl::side left_right,
+                 oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_diag,
                  std::int64_t m,
                  std::int64_t n,
                  value_or_pointer<T> alpha,

--- a/source/elements/oneMKL/source/domains/blas/trmv.rst
+++ b/source/elements/oneMKL/source/domains/blas/trmv.rst
@@ -52,9 +52,9 @@ trmv (Buffer Version)
 
    namespace oneapi::mkl::blas::column_major {
        void trmv(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
-                 onemkl::transpose trans,
-                 onemkl::diag unit_nonunit,
+                 oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_nonunit,
                  std::int64_t n,
                  sycl::buffer<T,1> &a,
                  std::int64_t lda,
@@ -65,9 +65,9 @@ trmv (Buffer Version)
 
    namespace oneapi::mkl::blas::row_major {
        void trmv(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
-                 onemkl::transpose trans,
-                 onemkl::diag unit_nonunit,
+                 oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_nonunit,
                  std::int64_t n,
                  sycl::buffer<T,1> &a,
                  std::int64_t lda,
@@ -150,9 +150,9 @@ trmv (USM Version)
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event trmv(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
-                        onemkl::transpose trans,
-                        onemkl::diag unit_nonunit,
+                        oneapi::mkl::uplo upper_lower,
+                        oneapi::mkl::transpose trans,
+                        oneapi::mkl::diag unit_nonunit,
                         std::int64_t n,
                         const T *a,
                         std::int64_t lda,
@@ -164,9 +164,9 @@ trmv (USM Version)
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event trmv(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
-                        onemkl::transpose trans,
-                        onemkl::diag unit_nonunit,
+                        oneapi::mkl::uplo upper_lower,
+                        oneapi::mkl::transpose trans,
+                        oneapi::mkl::diag unit_nonunit,
                         std::int64_t n,
                         const T *a,
                         std::int64_t lda,

--- a/source/elements/oneMKL/source/domains/blas/trsm.rst
+++ b/source/elements/oneMKL/source/domains/blas/trsm.rst
@@ -80,10 +80,10 @@ trsm (Buffer Version)
 
    namespace oneapi::mkl::blas::column_major {
        void trsm(sycl::queue &queue,
-                 onemkl::side left_right,
-                 onemkl::uplo upper_lower,
-                 onemkl::transpose transa,
-                 onemkl::diag unit_diag,
+                 oneapi::mkl::side left_right,
+                 oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose transa,
+                 oneapi::mkl::diag unit_diag,
                  std::int64_t m,
                  std::int64_t n,
                  T alpha,
@@ -96,10 +96,10 @@ trsm (Buffer Version)
 
    namespace oneapi::mkl::blas::row_major {
        void trsm(sycl::queue &queue,
-                 onemkl::side left_right,
-                 onemkl::uplo upper_lower,
-                 onemkl::transpose transa,
-                 onemkl::diag unit_diag,
+                 oneapi::mkl::side left_right,
+                 oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose transa,
+                 oneapi::mkl::diag unit_diag,
                  std::int64_t m,
                  std::int64_t n,
                  T alpha,
@@ -207,10 +207,10 @@ trsm (Buffer Version)
 
    namespace oneapi::mkl::blas::column_major {
        void trsm(sycl::queue &queue,
-                 onemkl::side left_right,
-                 onemkl::uplo upper_lower,
-                 onemkl::transpose trans,
-                 onemkl::diag unit_diag,
+                 oneapi::mkl::side left_right,
+                 oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_diag,
                  std::int64_t m,
                  std::int64_t n,
                  T alpha,
@@ -227,10 +227,10 @@ trsm (Buffer Version)
 
    namespace oneapi::mkl::blas::row_major {
        void trsm(sycl::queue &queue,
-                 onemkl::side left_right,
-                 onemkl::uplo upper_lower,
-                 onemkl::transpose trans,
-                 onemkl::diag unit_diag,
+                 oneapi::mkl::side left_right,
+                 oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_diag,
                  std::int64_t m,
                  std::int64_t n,
                  T alpha,
@@ -339,10 +339,10 @@ trsm (USM Version)
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event trsm(sycl::queue &queue,
-                        onemkl::side left_right,
-                        onemkl::uplo upper_lower,
-                        onemkl::transpose transa,
-                        onemkl::diag unit_diag,
+                        oneapi::mkl::side left_right,
+                        oneapi::mkl::uplo upper_lower,
+                        oneapi::mkl::transpose transa,
+                        oneapi::mkl::diag unit_diag,
                         std::int64_t m,
                         std::int64_t n,
                         value_or_pointer<T> alpha,
@@ -356,10 +356,10 @@ trsm (USM Version)
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event trsm(sycl::queue &queue,
-                        onemkl::side left_right,
-                        onemkl::uplo upper_lower,
-                        onemkl::transpose transa,
-                        onemkl::diag unit_diag,
+                        oneapi::mkl::side left_right,
+                        oneapi::mkl::uplo upper_lower,
+                        oneapi::mkl::transpose transa,
+                        oneapi::mkl::diag unit_diag,
                         std::int64_t m,
                         std::int64_t n,
                         value_or_pointer<T> alpha,
@@ -482,10 +482,10 @@ trsm (USM Version)
 
    namespace oneapi::mkl::blas::column_major {
        void trsm(sycl::queue &queue,
-                 onemkl::side left_right,
-                 onemkl::uplo upper_lower,
-                 onemkl::transpose trans,
-                 onemkl::diag unit_diag,
+                 oneapi::mkl::side left_right,
+                 oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_diag,
                  std::int64_t m,
                  std::int64_t n,
                  value_or_pointer<T> alpha,
@@ -503,10 +503,10 @@ trsm (USM Version)
 
    namespace oneapi::mkl::blas::row_major {
        void trsm(sycl::queue &queue,
-                 onemkl::side left_right,
-                 onemkl::uplo upper_lower,
-                 onemkl::transpose trans,
-                 onemkl::diag unit_diag,
+                 oneapi::mkl::side left_right,
+                 oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_diag,
                  std::int64_t m,
                  std::int64_t n,
                  value_or_pointer<T> alpha,

--- a/source/elements/oneMKL/source/domains/blas/trsm_batch.rst
+++ b/source/elements/oneMKL/source/domains/blas/trsm_batch.rst
@@ -42,7 +42,7 @@ The strided API operation is defined as:
 
    for i = 0 … batch_size – 1
        A and B are matrices at offset i * stridea and i * strideb in a and b.
-       if (left_right == onemkl::side::left) then
+       if (left_right == oneapi::mkl::side::left) then
            compute X such that op(A) * X = alpha * B
        else
            compute X such that X * op(A) = alpha * B
@@ -77,10 +77,10 @@ of matrices in ``a`` and ``b`` buffers are given by the ``batch_size`` parameter
 
    namespace oneapi::mkl::blas::column_major {
        void trsm_batch(sycl::queue &queue,
-                       onemkl::side left_right,
-                       onemkl::uplo upper_lower,
-                       onemkl::transpose trans,
-                       onemkl::diag unit_diag,
+                       oneapi::mkl::side left_right,
+                       oneapi::mkl::uplo upper_lower,
+                       oneapi::mkl::transpose trans,
+                       oneapi::mkl::diag unit_diag,
                        std::int64_t m,
                        std::int64_t n,
                        T alpha,
@@ -96,10 +96,10 @@ of matrices in ``a`` and ``b`` buffers are given by the ``batch_size`` parameter
 
    namespace oneapi::mkl::blas::row_major {
        void trsm_batch(sycl::queue &queue,
-                       onemkl::side left_right,
-                       onemkl::uplo upper_lower,
-                       onemkl::transpose trans,
-                       onemkl::diag unit_diag,
+                       oneapi::mkl::side left_right,
+                       oneapi::mkl::uplo upper_lower,
+                       oneapi::mkl::transpose trans,
+                       oneapi::mkl::diag unit_diag,
                        std::int64_t m,
                        std::int64_t n,
                        T alpha,
@@ -218,7 +218,7 @@ The group API operation is defined as:
    for i = 0 … group_count – 1
        for j = 0 … group_size – 1
            A and B are matrices in a[idx] and b[idx]
-           if (left_right == onemkl::side::left) then
+           if (left_right == oneapi::mkl::side::left) then
                compute X such that op(A) * X = alpha[i] * B
            else
                compute X such that X * op(A) = alpha[i] * B
@@ -234,7 +234,7 @@ The strided API operation is defined as:
 
    for i = 0 … batch_size – 1
        A and B are matrices at offset i * stridea and i * strideb in a and b.
-       if (left_right == onemkl::side::left) then
+       if (left_right == oneapi::mkl::side::left) then
            compute X such that op(A) * X = alpha * B
        else
            compute X such that X * op(A) = alpha * B
@@ -275,10 +275,10 @@ in ``a`` and ``b`` are given by the ``batch_size`` parameter.
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event trsm_batch(sycl::queue &queue,
-                              const onemkl::side *left_right,
-                              const onemkl::uplo *upper_lower,
-                              const onemkl::transpose *trans,
-                              const onemkl::diag *unit_diag,
+                              const oneapi::mkl::side *left_right,
+                              const oneapi::mkl::uplo *upper_lower,
+                              const oneapi::mkl::transpose *trans,
+                              const oneapi::mkl::diag *unit_diag,
                               const std::int64_t *m,
                               const std::int64_t *n,
                               const T *alpha,
@@ -294,10 +294,10 @@ in ``a`` and ``b`` are given by the ``batch_size`` parameter.
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event trsm_batch(sycl::queue &queue,
-                              const onemkl::side *left_right,
-                              const onemkl::uplo *upper_lower,
-                              const onemkl::transpose *trans,
-                              const onemkl::diag *unit_diag,
+                              const oneapi::mkl::side *left_right,
+                              const oneapi::mkl::uplo *upper_lower,
+                              const oneapi::mkl::transpose *trans,
+                              const oneapi::mkl::diag *unit_diag,
                               const std::int64_t *m,
                               const std::int64_t *n,
                               const T *alpha,
@@ -318,20 +318,20 @@ in ``a`` and ``b`` are given by the ``batch_size`` parameter.
       The queue where the routine should be executed.
 
    left_right
-      Array of ``group_count`` ``onemkl::side`` values. ``left_right[i]`` specifies whether ``A`` multiplies
+      Array of ``group_count`` ``oneapi::mkl::side`` values. ``left_right[i]`` specifies whether ``A`` multiplies
       ``X`` on the left (``side::left``) or on the right
       (``side::right``) for every ``trsm`` operation in group ``i``. See :ref:`onemkl_datatypes` for more details.
 
    upper_lower
-      Array of ``group_count`` ``onemkl::uplo`` values. ``upper_lower[i]`` specifies whether ``A`` is upper or lower
+      Array of ``group_count`` ``oneapi::mkl::uplo`` values. ``upper_lower[i]`` specifies whether ``A`` is upper or lower
       triangular for every matrix in group ``i``. See :ref:`onemkl_datatypes` for more details.
 
    trans
-      Array of ``group_count`` ``onemkl::transpose`` values. ``trans[i]`` specifies the form of op(``A``) used
+      Array of ``group_count`` ``oneapi::mkl::transpose`` values. ``trans[i]`` specifies the form of op(``A``) used
       for every ``trsm`` operation in group ``i``. See :ref:`onemkl_datatypes` for more details.
 
    unit_diag
-      Array of ``group_count`` ``onemkl::diag`` values. ``unit_diag[i]`` specifies whether ``A`` is assumed to
+      Array of ``group_count`` ``oneapi::mkl::diag`` values. ``unit_diag[i]`` specifies whether ``A`` is assumed to
       be unit triangular (all diagonal elements are 1) for every matrix in group ``i``. See :ref:`onemkl_datatypes` for more details.
 
    m
@@ -404,10 +404,10 @@ in ``a`` and ``b`` are given by the ``batch_size`` parameter.
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event trsm_batch(sycl::queue &queue,
-                              onemkl::side left_right,
-                              onemkl::uplo upper_lower,
-                              onemkl::transpose trans,
-                              onemkl::diag unit_diag,
+                              oneapi::mkl::side left_right,
+                              oneapi::mkl::uplo upper_lower,
+                              oneapi::mkl::transpose trans,
+                              oneapi::mkl::diag unit_diag,
                               std::int64_t m,
                               std::int64_t n,
                               value_or_pointer<T> alpha,
@@ -424,10 +424,10 @@ in ``a`` and ``b`` are given by the ``batch_size`` parameter.
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event trsm_batch(sycl::queue &queue,
-                              onemkl::side left_right,
-                              onemkl::uplo upper_lower,
-                              onemkl::transpose trans,
-                              onemkl::diag unit_diag,
+                              oneapi::mkl::side left_right,
+                              oneapi::mkl::uplo upper_lower,
+                              oneapi::mkl::transpose trans,
+                              oneapi::mkl::diag unit_diag,
                               std::int64_t m,
                               std::int64_t n,
                               value_or_pointer<T> alpha,

--- a/source/elements/oneMKL/source/domains/blas/trsv.rst
+++ b/source/elements/oneMKL/source/domains/blas/trsv.rst
@@ -53,9 +53,9 @@ trsv (Buffer Version)
 
    namespace oneapi::mkl::blas::column_major {
        void trsv(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
-                 onemkl::transpose trans,
-                 onemkl::diag unit_nonunit,
+                 oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_nonunit,
                  std::int64_t n,
                  sycl::buffer<T,1> &a,
                  std::int64_t lda,
@@ -66,9 +66,9 @@ trsv (Buffer Version)
 
    namespace oneapi::mkl::blas::row_major {
        void trsv(sycl::queue &queue,
-                 onemkl::uplo upper_lower,
-                 onemkl::transpose trans,
-                 onemkl::diag unit_nonunit,
+                 oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_nonunit,
                  std::int64_t n,
                  sycl::buffer<T,1> &a,
                  std::int64_t lda,
@@ -150,9 +150,9 @@ trsv (USM Version)
 
    namespace oneapi::mkl::blas::column_major {
        sycl::event trsv(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
-                        onemkl::transpose trans,
-                        onemkl::diag unit_nonunit,
+                        oneapi::mkl::uplo upper_lower,
+                        oneapi::mkl::transpose trans,
+                        oneapi::mkl::diag unit_nonunit,
                         std::int64_t n,
                         const T *a,
                         std::int64_t lda,
@@ -164,9 +164,9 @@ trsv (USM Version)
 
    namespace oneapi::mkl::blas::row_major {
        sycl::event trsv(sycl::queue &queue,
-                        onemkl::uplo upper_lower,
-                        onemkl::transpose trans,
-                        onemkl::diag unit_nonunit,
+                        oneapi::mkl::uplo upper_lower,
+                        oneapi::mkl::transpose trans,
+                        oneapi::mkl::diag unit_nonunit,
                         std::int64_t n,
                         const T *a,
                         std::int64_t lda,


### PR DESCRIPTION
In this PR, `onemkl::` is replaced ith `oneapi::mkl::` for relevant parameters in OneMKL BLAS routines.
This PR also is fixing #534 