### PR TITLE
[DFT] Constrain data_type in compute_*ward real-real inplace

### DIFF
--- a/source/elements/oneMKL/source/domains/dft/compute_backward.rst
+++ b/source/elements/oneMKL/source/domains/dft/compute_backward.rst
@@ -108,13 +108,15 @@ compute_backward (Buffer version)
    inout_re
       ``sycl::buffer`` object of sufficient capacity to store the elements
       defining the real parts of all the relevant data sequences, as configured
-      by ``desc``. Only with complex descriptors configured for in-place operations with
+      by ``desc``. ``data_type`` must be single or double precision floating-point, as 
+      described by the descriptor's precision. Only with complex descriptors configured for in-place operations with
       :ref:`onemkl_dft_complex_storage_real_real`.
 
    inout_im
       ``sycl::buffer`` object of sufficient capacity to store the elements
       defining the imaginary parts of all the relevant data sequences, as
-      configured by ``desc``. Only with complex descriptors configured for in-place
+      configured by ``desc``. ``data_type`` must be single or double precision floating-point, as 
+      described by the descriptor's precision. Only with complex descriptors configured for in-place
       operations with :ref:`onemkl_dft_complex_storage_real_real`.
 
    in
@@ -149,13 +151,15 @@ compute_backward (Buffer version)
    inout_re
       ``sycl::buffer`` object of sufficient capacity to store the elements
       defining the real parts of all the relevant data sequences, as configured
-      by ``desc``. Only with complex descriptors configured for in-place operations with
+      by ``desc``. ``data_type`` must be single or double precision floating-point, as 
+      described by the descriptor's precision. Only with complex descriptors configured for in-place operations with
       :ref:`onemkl_dft_complex_storage_real_real`.
 
    inout_im
       ``sycl::buffer`` object of sufficient capacity to store the elements
       defining the imaginary parts of all the relevant data sequences, as
-      configured by ``desc``. Only with complex descriptors configured for in-place
+      configured by ``desc``. ``data_type`` must be single or double precision floating-point, as 
+      described by the descriptor's precision. Only with complex descriptors configured for in-place
       operations with :ref:`onemkl_dft_complex_storage_real_real`.
 
    out
@@ -267,13 +271,15 @@ compute_backward (USM version)
    inout_re
       Pointer to USM allocation of sufficient capacity to store the elements
       defining the real parts of all the relevant data sequences, as configured
-      by ``desc``. Only with complex descriptors configured for in-place operations with
+      by ``desc``. ``data_type`` must be single or double precision floating-point, as 
+      described by the descriptor's precision. Only with complex descriptors configured for in-place operations with
       :ref:`onemkl_dft_complex_storage_real_real`.
 
    inout_im
       Pointer to USM allocation of sufficient capacity to store the elements
       defining the imaginary parts of all the relevant data sequences, as
-      configured by ``desc``. Only with complex descriptors configured for in-place
+      configured by ``desc``. ``data_type`` must be single or double precision floating-point, as 
+      described by the descriptor's precision. Only with complex descriptors configured for in-place
       operations with :ref:`onemkl_dft_complex_storage_real_real`.
 
    in
@@ -312,13 +318,15 @@ compute_backward (USM version)
    inout_re
       Pointer to USM allocation of sufficient capacity to store the elements
       defining the real parts of all the relevant data sequences, as
-      configured by ``desc``. Only with complex descriptors configured for in-place
+      configured by ``desc``. ``data_type`` must be single or double precision floating-point, as 
+      described by the descriptor's precision. Only with complex descriptors configured for in-place
       operations with :ref:`onemkl_dft_complex_storage_real_real`.
 
    inout_im
       Pointer to USM allocation of sufficient capacity to store the elements
       defining the imaginary parts of all the relevant data sequences, as
-      configured by ``desc``. Only with complex descriptors configured for in-place
+      configured by ``desc``. ``data_type`` must be the floating-point type 
+      described by descriptor's precision. Only with complex descriptors configured for in-place
       operations with :ref:`onemkl_dft_complex_storage_real_real`.
 
    out

--- a/source/elements/oneMKL/source/domains/dft/compute_backward.rst
+++ b/source/elements/oneMKL/source/domains/dft/compute_backward.rst
@@ -324,13 +324,13 @@ compute_backward (USM version)
       defining the real parts of all the relevant data sequences, as configured
       by ``desc``. ``data_type`` must be single or double precision
       floating-point, as described by the descriptor's precision. Only with
-      complex descriptors configured for in-place
-      operations with :ref:`onemkl_dft_complex_storage_real_real`.
+      complex descriptors configured for in-place operations with
+      :ref:`onemkl_dft_complex_storage_real_real`.
 
    inout_im
       Pointer to USM allocation of sufficient capacity to store the elements
       defining the imaginary parts of all the relevant data sequences, as
-      configured by ``desc``.  must be single or double precision
+      configured by ``desc``. ``data_type``  must be single or double precision
       floating-point, as described by the descriptor's precision. Only with
       complex descriptors configured for in-place operations with
       :ref:`onemkl_dft_complex_storage_real_real`.

--- a/source/elements/oneMKL/source/domains/dft/compute_backward.rst
+++ b/source/elements/oneMKL/source/domains/dft/compute_backward.rst
@@ -151,16 +151,18 @@ compute_backward (Buffer version)
    inout_re
       ``sycl::buffer`` object of sufficient capacity to store the elements
       defining the real parts of all the relevant data sequences, as configured
-      by ``desc``. ``data_type`` must be single or double precision floating-point, as 
-      described by the descriptor's precision. Only with complex descriptors configured for in-place operations with
+      by ``desc``. ``data_type`` must be single or double precision
+      floating-point, as described by the descriptor's precision. Only with
+      complex descriptors configured for in-place operations with
       :ref:`onemkl_dft_complex_storage_real_real`.
 
    inout_im
       ``sycl::buffer`` object of sufficient capacity to store the elements
       defining the imaginary parts of all the relevant data sequences, as
-      configured by ``desc``. ``data_type`` must be single or double precision floating-point, as 
-      described by the descriptor's precision. Only with complex descriptors configured for in-place
-      operations with :ref:`onemkl_dft_complex_storage_real_real`.
+      configured by ``desc``. ``data_type`` must be single or double precision
+      floating-point, as described by the descriptor's precision. Only with
+      complex descriptors configured for in-place operations with
+      :ref:`onemkl_dft_complex_storage_real_real`.
 
    out
       ``sycl::buffer`` object of sufficient capacity to store the elements
@@ -271,16 +273,18 @@ compute_backward (USM version)
    inout_re
       Pointer to USM allocation of sufficient capacity to store the elements
       defining the real parts of all the relevant data sequences, as configured
-      by ``desc``. ``data_type`` must be single or double precision floating-point, as 
-      described by the descriptor's precision. Only with complex descriptors configured for in-place operations with
+      by ``desc``. ``data_type`` must be single or double precision
+      floating-point, as described by the descriptor's precision. Only with
+      complex descriptors configured for in-place operations with
       :ref:`onemkl_dft_complex_storage_real_real`.
 
    inout_im
       Pointer to USM allocation of sufficient capacity to store the elements
       defining the imaginary parts of all the relevant data sequences, as
-      configured by ``desc``. ``data_type`` must be single or double precision floating-point, as 
-      described by the descriptor's precision. Only with complex descriptors configured for in-place
-      operations with :ref:`onemkl_dft_complex_storage_real_real`.
+      configured by ``desc``. ``data_type`` must be single or double precision
+      floating-point, as described by the descriptor's precision. Only with
+      complex descriptors configured for in-place operations with
+      :ref:`onemkl_dft_complex_storage_real_real`.
 
    in
       Pointer to USM allocation of sufficient capacity to store the elements
@@ -317,17 +321,19 @@ compute_backward (USM version)
 
    inout_re
       Pointer to USM allocation of sufficient capacity to store the elements
-      defining the real parts of all the relevant data sequences, as
-      configured by ``desc``. ``data_type`` must be single or double precision floating-point, as 
-      described by the descriptor's precision. Only with complex descriptors configured for in-place
+      defining the real parts of all the relevant data sequences, as configured
+      by ``desc``. ``data_type`` must be single or double precision
+      floating-point, as described by the descriptor's precision. Only with
+      complex descriptors configured for in-place
       operations with :ref:`onemkl_dft_complex_storage_real_real`.
 
    inout_im
       Pointer to USM allocation of sufficient capacity to store the elements
       defining the imaginary parts of all the relevant data sequences, as
-      configured by ``desc``. ``data_type`` must be the floating-point type 
-      described by descriptor's precision. Only with complex descriptors configured for in-place
-      operations with :ref:`onemkl_dft_complex_storage_real_real`.
+      configured by ``desc``.  must be single or double precision
+      floating-point, as described by the descriptor's precision. Only with
+      complex descriptors configured for in-place operations with
+      :ref:`onemkl_dft_complex_storage_real_real`.
 
    out
       Pointer to USM allocation of sufficient capacity to store the elements

--- a/source/elements/oneMKL/source/domains/dft/compute_forward.rst
+++ b/source/elements/oneMKL/source/domains/dft/compute_forward.rst
@@ -108,13 +108,15 @@ compute_forward (Buffer version)
    inout_re
       ``sycl::buffer`` object of sufficient capacity to store the elements
       defining the real parts of all the relevant data sequences, as
-      configured by ``desc``. Only with complex descriptors configured for in-place
+      configured by ``desc``. ``data_type`` must be single or double precision floating-point, as 
+      described by the descriptor's precision. Only with complex descriptors configured for in-place
       operations with :ref:`onemkl_dft_complex_storage_real_real`.
 
    inout_im
       ``sycl::buffer`` object of sufficient capacity to store the elements
       defining the imaginary parts of all the relevant data sequences, as
-      configured by ``desc``. Only with complex descriptors configured for in-place
+      configured by ``desc``. ``data_type`` must be single or double precision floating-point, as 
+      described by the descriptor's precision. Only with complex descriptors configured for in-place
       operations with :ref:`onemkl_dft_complex_storage_real_real`.
 
    in
@@ -149,13 +151,15 @@ compute_forward (Buffer version)
    inout_re
       ``sycl::buffer`` object of sufficient capacity to store the elements
       defining the real parts of all the relevant data sequences, as configured
-      by ``desc``. Only with complex descriptors configured for in-place operations with
+      by ``desc``. ``data_type`` must be single or double precision floating-point, as 
+      described by the descriptor's precision. Only with complex descriptors configured for in-place operations with
       :ref:`onemkl_dft_complex_storage_real_real`.
 
    inout_im
       ``sycl::buffer`` object of sufficient capacity to store the elements
       defining the imaginary parts of all the relevant data sequences, as
-      configured by ``desc``. Only with complex descriptors configured for in-place
+      configured by ``desc``. ``data_type`` must be single or double precision floating-point, as 
+      described by the descriptor's precision. Only with complex descriptors configured for in-place
       operations with :ref:`onemkl_dft_complex_storage_real_real`.
 
    out
@@ -267,13 +271,15 @@ compute_forward (USM version)
    inout_re
       Pointer to USM allocation of sufficient capacity to store the elements
       defining the real parts of all the relevant data sequences, as configured
-      by ``desc``. Only with complex descriptors configured for in-place operations with
+      by ``desc``. ``data_type`` must be single or double precision floating-point, as 
+      described by the descriptor's precision. Only with complex descriptors configured for in-place operations with
       :ref:`onemkl_dft_complex_storage_real_real`.
 
    inout_im
       Pointer to USM allocation of sufficient capacity to store the elements
       defining the imaginary parts of all the relevant data sequences, as
-      configured by ``desc``. Only with complex descriptors configured for in-place
+      configured by ``desc``. ``data_type`` must be single or double precision floating-point, as 
+      described by the descriptor's precision. Only with complex descriptors configured for in-place
       operations with :ref:`onemkl_dft_complex_storage_real_real`.
 
    in
@@ -312,13 +318,15 @@ compute_forward (USM version)
    inout_re
       Pointer to USM allocation of sufficient capacity to store the elements
       defining the real parts of all the relevant data sequences, as configured
-      by ``desc``. Only with complex descriptors configured for in-place operations with
+      by ``desc``. ``data_type`` must be single or double precision floating-point, as 
+      described by the descriptor's precision. Only with complex descriptors configured for in-place operations with
       :ref:`onemkl_dft_complex_storage_real_real`.
 
    inout_im
       Pointer to USM allocation of sufficient capacity to store the elements
       defining the imaginary parts of all the relevant data sequences, as
-      configured by ``desc``. Only with complex descriptors configured for in-place
+      configured by ``desc``. ``data_type`` must be single or double precision floating-point, as 
+      described by the descriptor's precision. Only with complex descriptors configured for in-place
       operations with :ref:`onemkl_dft_complex_storage_real_real`.
 
    out

--- a/source/elements/oneMKL/source/domains/dft/compute_forward.rst
+++ b/source/elements/oneMKL/source/domains/dft/compute_forward.rst
@@ -107,17 +107,19 @@ compute_forward (Buffer version)
 
    inout_re
       ``sycl::buffer`` object of sufficient capacity to store the elements
-      defining the real parts of all the relevant data sequences, as
-      configured by ``desc``. ``data_type`` must be single or double precision floating-point, as 
-      described by the descriptor's precision. Only with complex descriptors configured for in-place
-      operations with :ref:`onemkl_dft_complex_storage_real_real`.
+      defining the real parts of all the relevant data sequences, as configured
+      by ``desc``. ``data_type`` must be single or double precision
+      floating-point, as described by the descriptor's precision. Only with
+      complex descriptors configured for in-place operations with
+      :ref:`onemkl_dft_complex_storage_real_real`.
 
    inout_im
       ``sycl::buffer`` object of sufficient capacity to store the elements
       defining the imaginary parts of all the relevant data sequences, as
-      configured by ``desc``. ``data_type`` must be single or double precision floating-point, as 
-      described by the descriptor's precision. Only with complex descriptors configured for in-place
-      operations with :ref:`onemkl_dft_complex_storage_real_real`.
+      configured by ``desc``. ``data_type`` must be single or double precision
+      floating-point, as described by the descriptor's precision. Only with
+      complex descriptors configured for in-place operations with
+      :ref:`onemkl_dft_complex_storage_real_real`.
 
    in
       ``sycl::buffer`` object of sufficient capacity to store the elements

--- a/source/elements/oneMKL/source/domains/dft/compute_forward.rst
+++ b/source/elements/oneMKL/source/domains/dft/compute_forward.rst
@@ -151,16 +151,18 @@ compute_forward (Buffer version)
    inout_re
       ``sycl::buffer`` object of sufficient capacity to store the elements
       defining the real parts of all the relevant data sequences, as configured
-      by ``desc``. ``data_type`` must be single or double precision floating-point, as 
-      described by the descriptor's precision. Only with complex descriptors configured for in-place operations with
+      by ``desc``. ``data_type`` must be single or double precision
+      floating-point, as described by the descriptor's precision. Only with
+      complex descriptors configured for in-place operations with
       :ref:`onemkl_dft_complex_storage_real_real`.
 
    inout_im
       ``sycl::buffer`` object of sufficient capacity to store the elements
       defining the imaginary parts of all the relevant data sequences, as
-      configured by ``desc``. ``data_type`` must be single or double precision floating-point, as 
-      described by the descriptor's precision. Only with complex descriptors configured for in-place
-      operations with :ref:`onemkl_dft_complex_storage_real_real`.
+      configured by ``desc``. ``data_type`` must be single or double precision
+      floating-point, as described by the descriptor's precision. Only with
+      complex descriptors configured for in-place operations with
+      :ref:`onemkl_dft_complex_storage_real_real`.
 
    out
       ``sycl::buffer`` object of sufficient capacity to store the elements
@@ -271,16 +273,18 @@ compute_forward (USM version)
    inout_re
       Pointer to USM allocation of sufficient capacity to store the elements
       defining the real parts of all the relevant data sequences, as configured
-      by ``desc``. ``data_type`` must be single or double precision floating-point, as 
-      described by the descriptor's precision. Only with complex descriptors configured for in-place operations with
+      by ``desc``. ``data_type`` must be single or double precision
+      floating-point, as described by the descriptor's precision. Only with
+      complex descriptors configured for in-place operations with
       :ref:`onemkl_dft_complex_storage_real_real`.
 
    inout_im
       Pointer to USM allocation of sufficient capacity to store the elements
       defining the imaginary parts of all the relevant data sequences, as
-      configured by ``desc``. ``data_type`` must be single or double precision floating-point, as 
-      described by the descriptor's precision. Only with complex descriptors configured for in-place
-      operations with :ref:`onemkl_dft_complex_storage_real_real`.
+      configured by ``desc``. ``data_type`` must be single or double precision
+      floating-point, as described by the descriptor's precision. Only with
+      complex descriptors configured for in-place operations with
+      :ref:`onemkl_dft_complex_storage_real_real`.
 
    in
       Pointer to USM allocation of sufficient capacity to store the elements
@@ -318,16 +322,18 @@ compute_forward (USM version)
    inout_re
       Pointer to USM allocation of sufficient capacity to store the elements
       defining the real parts of all the relevant data sequences, as configured
-      by ``desc``. ``data_type`` must be single or double precision floating-point, as 
-      described by the descriptor's precision. Only with complex descriptors configured for in-place operations with
+      by ``desc``. ``data_type`` must be single or double precision
+      floating-point, as described by the descriptor's precision. Only with
+      complex descriptors configured for in-place operations with
       :ref:`onemkl_dft_complex_storage_real_real`.
 
    inout_im
       Pointer to USM allocation of sufficient capacity to store the elements
       defining the imaginary parts of all the relevant data sequences, as
-      configured by ``desc``. ``data_type`` must be single or double precision floating-point, as 
-      described by the descriptor's precision. Only with complex descriptors configured for in-place
-      operations with :ref:`onemkl_dft_complex_storage_real_real`.
+      configured by ``desc``. ``data_type`` must be single or double precision
+      floating-point, as described by the descriptor's precision. Only with
+      complex descriptors configured for in-place operations with
+      :ref:`onemkl_dft_complex_storage_real_real`.
 
    out
       Pointer to USM allocation of sufficient capacity to store the elements


### PR DESCRIPTION
* The compute_*ward real-real implace overload can be selected when the user intends to use the complex-complex out-of-place overload.
* This suggestion stops this from happening when the user uses non-float arguments that are presumably intended for the complex-complex overload.

For a complete description of the issue, see https://github.com/oneapi-src/oneMKL/issues/499, and also PR with this change to the spec adopted at https://github.com/oneapi-src/oneMKL/pull/503.