### PR TITLE
[oneDPL] Improve requirements for iterator source types

### DIFF
--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -371,7 +371,7 @@ using the source iterator and unary function object provided.
 
 ``zip_iterator`` is an iterator-like type defined over one or more iterators. When dereferenced,
 the value returned from ``zip_iterator`` is a tuple of the values returned by dereferencing the
-source iterators over which the ``zip_iterator`` is defined.  The arithmetic operators of
+source iterators over which the ``zip_iterator`` is defined. The arithmetic operators of
 ``zip_iterator`` update the source iterators of a ``zip_iterator`` instance as though the
 operation were applied to each of these iterators. The types ``T`` within the template pack 
 ``Iterators...`` must satisfy ``AdaptingIteratorSource``.

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -96,13 +96,13 @@ Let us define a named requirement, :code:`AdaptingIteratorSource`, to describe v
 types that can be used as source for oneDPL iterators as described below.
 The type :code:`Iter` satisfies the :code:`AdaptingIteratorSource` named requirement if it is any of the following:
 
- * a random access iterator
- * the unspecified iterator-like type returned by :code:`oneapi::dpl::begin` or :code:`oneapi::dpl::end`
- * a :code:`permutation_iterator`
- * a :code:`transform_iterator`
- * a :code:`counting_iterator`
- * a :code:`discard_iterator`
- * a :code:`zip_iterator`
+ * A random access iterator
+ * The unspecified iterator-like type returned by :code:`oneapi::dpl::begin` or :code:`oneapi::dpl::end`
+ * A :code:`permutation_iterator`
+ * A :code:`transform_iterator`
+ * A :code:`counting_iterator`
+ * A :code:`discard_iterator`
+ * A :code:`zip_iterator`
 
 .. code:: cpp
 
@@ -238,12 +238,12 @@ iterator instances to determine their position in the index map. :code:`SourceIt
 
 The type :code:`IndexMap` must be one of the following:
 
- * a random access iterator
- * the unspecified iterator-like type returned by :code:`oneapi::dpl::begin` or :code:`oneapi::dpl::end`
- * a :code:`permutation_iterator`
- * a :code:`transform_iterator`
- * a :code:`counting_iterator`
- * a functor with a signature equivalent to :code:`T operator()(const T&) const` where :code:`T` is a
+ * A random access iterator
+ * The unspecified iterator-like type returned by :code:`oneapi::dpl::begin` or :code:`oneapi::dpl::end`
+ * A :code:`permutation_iterator`
+ * A :code:`transform_iterator`
+ * A :code:`counting_iterator`
+ * A functor with a signature equivalent to :code:`T operator()(const T&) const` where :code:`T` is a
    :code:`std::iterator_traits<SourceIterator>::difference_type`
 
 

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -96,7 +96,7 @@ Let us define a named requirement, :code:`ValidParallelIteratorSource`, to descr
 types that can be used as source for oneDPL's iterators as described below.
 The type :code:`Iter` satisfies the :code:`ValidParallelIteratorSource` named requirement if it satisfies
 at least one of the following:
- * :code:`Iter` satisfies the C++ named requirement :code:`LegacyRandomAccessIterator`
+ * :code:`Iter` is a random access iterator
  * :code:`Iter` is the unspecified iterator-like type returned by :code:`oneapi::dpl::begin` or :code:`oneapi::dpl::end`
  * :code:`Iter` is a valid :code:`permutation_iterator`
  * :code:`Iter` is a valid :code:`transform_iterator`
@@ -237,7 +237,7 @@ iterator instances to determine their position in the index map. :code:`SourceIt
 :code:`ValidParallelIteratorSource`.
 
 The type :code:`IndexMap` must satisfy at least one of the following:
- * :code:`IndexMap` satisfies the C++ named requirement :code:`LegacyRandomAccessIterator`
+ * :code:`IndexMap` is a random access iterator
  * :code:`IndexMap` is the unspecified iterator-like type returned by :code:`oneapi::dpl::begin` or :code:`oneapi::dpl::end`
  * :code:`IndexMap` is a valid :code:`permutation_iterator`
  * :code:`IndexMap` is a valid :code:`transform_iterator`

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -92,17 +92,17 @@ Iterators
 The oneDPL iterators are defined in the ``<oneapi/dpl/iterator>`` header,
 in ``namespace oneapi::dpl``.
 
-Let us define a named requirement, :code:`AdaptingIteratorSource`, to describe valid random access iterator-like
+Let us define a named requirement, ``AdaptingIteratorSource``, to describe valid random access iterator-like
 types that can be used as source for oneDPL iterators as described below.
-The type :code:`Iter` satisfies the :code:`AdaptingIteratorSource` named requirement if it is any of the following:
+The type ``Iter`` satisfies the ``AdaptingIteratorSource`` named requirement if it is any of the following:
 
  * A random access iterator
- * The unspecified iterator-like type returned by :code:`oneapi::dpl::begin` or :code:`oneapi::dpl::end`
- * A :code:`permutation_iterator`
- * A :code:`transform_iterator`
- * A :code:`counting_iterator`
- * A :code:`discard_iterator`
- * A :code:`zip_iterator`
+ * The unspecified iterator-like type returned by ``oneapi::dpl::begin`` or ``oneapi::dpl::end``
+ * A ``permutation_iterator``
+ * A ``transform_iterator``
+ * A ``counting_iterator``
+ * A ``discard_iterator``
+ * A ``zip_iterator``
 
 .. code:: cpp
 
@@ -233,18 +233,18 @@ defined by the source iterator provided, and whose iteration order over the dere
 is defined by either another iterator or a functor that maps the ``permutation_iterator`` index
 to the index of the source iterator. The arithmetic and comparison operators of
 ``permutation_iterator`` behave as if applied to integer counter values maintained by the
-iterator instances to determine their position in the index map. :code:`SourceIterator` must satisfy
-:code:`AdaptingIteratorSource`.
+iterator instances to determine their position in the index map. ``SourceIterator`` must satisfy
+``AdaptingIteratorSource``.
 
-The type :code:`IndexMap` must be one of the following:
+The type ``IndexMap`` must be one of the following:
 
  * A random access iterator
- * The unspecified iterator-like type returned by :code:`oneapi::dpl::begin` or :code:`oneapi::dpl::end`
- * A :code:`permutation_iterator`
- * A :code:`transform_iterator`
- * A :code:`counting_iterator`
- * A functor with a signature equivalent to :code:`T operator()(const T&) const` where :code:`T` is a
-   :code:`std::iterator_traits<SourceIterator>::difference_type`
+ * The unspecified iterator-like type returned by ``oneapi::dpl::begin`` or ``oneapi::dpl::end``
+ * A ``permutation_iterator``
+ * A ``transform_iterator``
+ * A ``counting_iterator``
+ * A functor with a signature equivalent to ``T operator()(const T&) const`` where ``T`` is a
+   ``std::iterator_traits<SourceIterator>::difference_type``
 
 
 ``permutation_iterator::operator*`` uses the counter value of the instance on which
@@ -314,8 +314,8 @@ defined by the unary function and source iterator provided. When dereferenced,
 element of the source iterator; dereference operations cannot be used to modify the elements of
 the source iterator unless the unary function result includes a reference to the element. The
 arithmetic and comparison operators of ``transform_iterator`` behave as if applied to the
-source iterator itself. The template type :code:`Iterator` must satisfy
-:code:`AdaptingIteratorSource`.
+source iterator itself. The template type ``Iterator`` must satisfy
+``AdaptingIteratorSource``.
 
 .. code:: cpp
 
@@ -373,8 +373,8 @@ using the source iterator and unary function object provided.
 the value returned from ``zip_iterator`` is a tuple of the values returned by dereferencing the
 source iterators over which the ``zip_iterator`` is defined.  The arithmetic operators of
 ``zip_iterator`` update the source iterators of a ``zip_iterator`` instance as though the
-operation were applied to each of these iterators. The types :code:`T` within the template pack 
-:code:`Iterators...` must satisfy :code:`AdaptingIteratorSource`.
+operation were applied to each of these iterators. The types ``T`` within the template pack 
+``Iterators...`` must satisfy ``AdaptingIteratorSource``.
 
 .. code:: cpp
 

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -103,7 +103,6 @@ at least one of the following:
  * :code:`Iter` is a valid :code:`counting_iterator`
  * :code:`Iter` is a valid :code:`discard_iterator`
  * :code:`Iter` is a valid :code:`zip_iterator`
- * :code:`Iter` is a valid :code:`std::reverse_iterator<It>` where :code:`It` satisfies :code:`ValidParallelIteratorSource`
 
 .. code:: cpp
 
@@ -243,7 +242,6 @@ The :code:`IndexMap` must satisfy at least one of the following:
  * :code:`IndexMap` is a valid :code:`permutation_iterator`
  * :code:`IndexMap` is a valid :code:`transform_iterator`
  * :code:`IndexMap` is a valid :code:`counting_iterator`
- * :code:`IndexMap` is a valid :code:`std::reverse_iterator<Iter>` where :code:`Iter` is a valid non-functor :code:`IndexMap` type
  * :code:`IndexMap` is a functor with a signature equivalent to :code:`T operator()(const T&) const` where
    :code:`T` is a `std::iterator_traits<SourceIterator>::difference_type`
 

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -92,6 +92,19 @@ Iterators
 The oneDPL iterators are defined in the ``<oneapi/dpl/iterator>`` header,
 in ``namespace oneapi::dpl``.
 
+Let us define a named requirement, :code:`ValidParallelIteratorSource`, to describe valid random access iterator-like
+types that can be used as source for oneDPL's iterators as described below.
+The type :code:`Iter` satisfies the :code:`ValidParallelIteratorSource` named requirement if it satisfies
+at least one of the following:
+ * :code:`Iter` satisfies the C++ named requirement :code:`LegacyRandomAccessIterator`
+ * :code:`Iter` is the unspecified iterator-like type returned by :code:`oneapi::dpl::begin` or :code:`oneapi::dpl::end`
+ * :code:`Iter` is a valid :code:`permutation_iterator`
+ * :code:`Iter` is a valid :code:`transform_iterator`
+ * :code:`Iter` is a valid :code:`counting_iterator`
+ * :code:`Iter` is a valid :code:`discard_iterator`
+ * :code:`Iter` is a valid :code:`zip_iterator`
+ * :code:`Iter` is a valid :code:`std::reverse_iterator<It>` where :code:`It` satisfies :code:`ValidParallelIteratorSource`
+
 .. code:: cpp
 
     template <typename Integral>
@@ -221,7 +234,19 @@ defined by the source iterator provided, and whose iteration order over the dere
 is defined by either another iterator or a functor that maps the ``permutation_iterator`` index
 to the index of the source iterator. The arithmetic and comparison operators of
 ``permutation_iterator`` behave as if applied to integer counter values maintained by the
-iterator instances to determine their position in the index map.
+iterator instances to determine their position in the index map. :code:`SourceIterator` must satisfy
+:code:`ValidParallelIteratorSource`.
+
+The :code:`IndexMap` must satisfy at least one of the following:
+ * :code:`IndexMap` satisfies the C++ named requirement :code:`LegacyRandomAccessIterator`
+ * :code:`IndexMap` is the unspecified iterator-like type returned by :code:`oneapi::dpl::begin` or :code:`oneapi::dpl::end`
+ * :code:`IndexMap` is a valid :code:`permutation_iterator`
+ * :code:`IndexMap` is a valid :code:`transform_iterator`
+ * :code:`IndexMap` is a valid :code:`counting_iterator`
+ * :code:`IndexMap` is a valid :code:`std::reverse_iterator<Iter>` where :code:`Iter` is a valid non-functor :code:`IndexMap` type
+ * :code:`IndexMap` is a functor with a signature equivalent to :code:`T operator()(const T&) const` where
+   :code:`T` is a `std::iterator_traits<SourceIterator>::difference_type`
+
 
 ``permutation_iterator::operator*`` uses the counter value of the instance on which
 it is invoked to index into the index map. The corresponding value in the map is then used
@@ -290,7 +315,8 @@ defined by the unary function and source iterator provided. When dereferenced,
 element of the source iterator; dereference operations cannot be used to modify the elements of
 the source iterator unless the unary function result includes a reference to the element. The
 arithmetic and comparison operators of ``transform_iterator`` behave as if applied to the
-source iterator itself.
+source iterator itself. The template type :code:`Iterator` must satisfy
+:code:`ValidParallelIteratorSource`.
 
 .. code:: cpp
 
@@ -346,9 +372,10 @@ using the source iterator and unary function object provided.
 
 ``zip_iterator`` is an iterator-like type defined over one or more iterators. When dereferenced,
 the value returned from ``zip_iterator`` is a tuple of the values returned by dereferencing the
-source iterators over which the ``zip_iterator`` is defined. The arithmetic operators of
+source iterators over which the ``zip_iterator`` is defined.  The arithmetic operators of
 ``zip_iterator`` update the source iterators of a ``zip_iterator`` instance as though the
-operation were applied to each of these iterators.
+operation were applied to each of these iterators. The types :code:`T` within the template pack 
+:code:`Iterators...` must satisfy :code:`ValidParallelIteratorSource`.
 
 .. code:: cpp
 

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -96,13 +96,14 @@ Let us define a named requirement, :code:`ValidParallelIteratorSource`, to descr
 types that can be used as source for oneDPL's iterators as described below.
 The type :code:`Iter` satisfies the :code:`ValidParallelIteratorSource` named requirement if it satisfies
 at least one of the following:
-* :code:`Iter` is a random access iterator
-* :code:`Iter` is the unspecified iterator-like type returned by :code:`oneapi::dpl::begin` or :code:`oneapi::dpl::end`
-* :code:`Iter` is a valid :code:`permutation_iterator`
-* :code:`Iter` is a valid :code:`transform_iterator`
-* :code:`Iter` is a valid :code:`counting_iterator`
-* :code:`Iter` is a valid :code:`discard_iterator`
-* :code:`Iter` is a valid :code:`zip_iterator`
+
+ * :code:`Iter` is a random access iterator
+ * :code:`Iter` is the unspecified iterator-like type returned by :code:`oneapi::dpl::begin` or :code:`oneapi::dpl::end`
+ * :code:`Iter` is a valid :code:`permutation_iterator`
+ * :code:`Iter` is a valid :code:`transform_iterator`
+ * :code:`Iter` is a valid :code:`counting_iterator`
+ * :code:`Iter` is a valid :code:`discard_iterator`
+ * :code:`Iter` is a valid :code:`zip_iterator`
 
 .. code:: cpp
 
@@ -237,13 +238,14 @@ iterator instances to determine their position in the index map. :code:`SourceIt
 :code:`ValidParallelIteratorSource`.
 
 The type :code:`IndexMap` must satisfy at least one of the following:
-* :code:`IndexMap` is a random access iterator
-* :code:`IndexMap` is the unspecified iterator-like type returned by :code:`oneapi::dpl::begin` or :code:`oneapi::dpl::end`
-* :code:`IndexMap` is a valid :code:`permutation_iterator`
-* :code:`IndexMap` is a valid :code:`transform_iterator`
-* :code:`IndexMap` is a valid :code:`counting_iterator`
-* :code:`IndexMap` is a functor with a signature equivalent to :code:`T operator()(const T&) const` where
-  :code:`T` is a `std::iterator_traits<SourceIterator>::difference_type`
+
+ * :code:`IndexMap` is a random access iterator
+ * :code:`IndexMap` is the unspecified iterator-like type returned by :code:`oneapi::dpl::begin` or :code:`oneapi::dpl::end`
+ * :code:`IndexMap` is a valid :code:`permutation_iterator`
+ * :code:`IndexMap` is a valid :code:`transform_iterator`
+ * :code:`IndexMap` is a valid :code:`counting_iterator`
+ * :code:`IndexMap` is a functor with a signature equivalent to :code:`T operator()(const T&) const` where
+   :code:`T` is a `std::iterator_traits<SourceIterator>::difference_type`
 
 
 ``permutation_iterator::operator*`` uses the counter value of the instance on which

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -236,7 +236,7 @@ to the index of the source iterator. The arithmetic and comparison operators of
 iterator instances to determine their position in the index map. :code:`SourceIterator` must satisfy
 :code:`ValidParallelIteratorSource`.
 
-The :code:`IndexMap` must satisfy at least one of the following:
+The type :code:`IndexMap` must satisfy at least one of the following:
  * :code:`IndexMap` satisfies the C++ named requirement :code:`LegacyRandomAccessIterator`
  * :code:`IndexMap` is the unspecified iterator-like type returned by :code:`oneapi::dpl::begin` or :code:`oneapi::dpl::end`
  * :code:`IndexMap` is a valid :code:`permutation_iterator`

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -92,18 +92,17 @@ Iterators
 The oneDPL iterators are defined in the ``<oneapi/dpl/iterator>`` header,
 in ``namespace oneapi::dpl``.
 
-Let us define a named requirement, :code:`ValidParallelIteratorSource`, to describe valid random access iterator-like
-types that can be used as source for oneDPL's iterators as described below.
-The type :code:`Iter` satisfies the :code:`ValidParallelIteratorSource` named requirement if it satisfies
-at least one of the following:
+Let us define a named requirement, :code:`AdaptingIteratorSource`, to describe valid random access iterator-like
+types that can be used as source for oneDPL iterators as described below.
+The type :code:`Iter` satisfies the :code:`AdaptingIteratorSource` named requirement if is any of the following:
 
- * :code:`Iter` is a random access iterator
- * :code:`Iter` is the unspecified iterator-like type returned by :code:`oneapi::dpl::begin` or :code:`oneapi::dpl::end`
- * :code:`Iter` is a valid :code:`permutation_iterator`
- * :code:`Iter` is a valid :code:`transform_iterator`
- * :code:`Iter` is a valid :code:`counting_iterator`
- * :code:`Iter` is a valid :code:`discard_iterator`
- * :code:`Iter` is a valid :code:`zip_iterator`
+ * a random access iterator
+ * the unspecified iterator-like type returned by :code:`oneapi::dpl::begin` or :code:`oneapi::dpl::end`
+ * a :code:`permutation_iterator`
+ * a :code:`transform_iterator`
+ * a :code:`counting_iterator`
+ * a :code:`discard_iterator`
+ * a :code:`zip_iterator`
 
 .. code:: cpp
 
@@ -235,17 +234,17 @@ is defined by either another iterator or a functor that maps the ``permutation_i
 to the index of the source iterator. The arithmetic and comparison operators of
 ``permutation_iterator`` behave as if applied to integer counter values maintained by the
 iterator instances to determine their position in the index map. :code:`SourceIterator` must satisfy
-:code:`ValidParallelIteratorSource`.
+:code:`AdaptingIteratorSource`.
 
-The type :code:`IndexMap` must satisfy at least one of the following:
+The type :code:`IndexMap` must be one of the following:
 
- * :code:`IndexMap` is a random access iterator
- * :code:`IndexMap` is the unspecified iterator-like type returned by :code:`oneapi::dpl::begin` or :code:`oneapi::dpl::end`
- * :code:`IndexMap` is a valid :code:`permutation_iterator`
- * :code:`IndexMap` is a valid :code:`transform_iterator`
- * :code:`IndexMap` is a valid :code:`counting_iterator`
- * :code:`IndexMap` is a functor with a signature equivalent to :code:`T operator()(const T&) const` where
-   :code:`T` is a `std::iterator_traits<SourceIterator>::difference_type`
+ * a random access iterator
+ * the unspecified iterator-like type returned by :code:`oneapi::dpl::begin` or :code:`oneapi::dpl::end`
+ * a :code:`permutation_iterator`
+ * a :code:`transform_iterator`
+ * a :code:`counting_iterator`
+ * a functor with a signature equivalent to :code:`T operator()(const T&) const` where :code:`T` is a
+   :code:`std::iterator_traits<SourceIterator>::difference_type`
 
 
 ``permutation_iterator::operator*`` uses the counter value of the instance on which
@@ -316,7 +315,7 @@ element of the source iterator; dereference operations cannot be used to modify 
 the source iterator unless the unary function result includes a reference to the element. The
 arithmetic and comparison operators of ``transform_iterator`` behave as if applied to the
 source iterator itself. The template type :code:`Iterator` must satisfy
-:code:`ValidParallelIteratorSource`.
+:code:`AdaptingIteratorSource`.
 
 .. code:: cpp
 
@@ -375,7 +374,7 @@ the value returned from ``zip_iterator`` is a tuple of the values returned by de
 source iterators over which the ``zip_iterator`` is defined.  The arithmetic operators of
 ``zip_iterator`` update the source iterators of a ``zip_iterator`` instance as though the
 operation were applied to each of these iterators. The types :code:`T` within the template pack 
-:code:`Iterators...` must satisfy :code:`ValidParallelIteratorSource`.
+:code:`Iterators...` must satisfy :code:`AdaptingIteratorSource`.
 
 .. code:: cpp
 

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -96,13 +96,13 @@ Let us define a named requirement, :code:`ValidParallelIteratorSource`, to descr
 types that can be used as source for oneDPL's iterators as described below.
 The type :code:`Iter` satisfies the :code:`ValidParallelIteratorSource` named requirement if it satisfies
 at least one of the following:
- * :code:`Iter` is a random access iterator
- * :code:`Iter` is the unspecified iterator-like type returned by :code:`oneapi::dpl::begin` or :code:`oneapi::dpl::end`
- * :code:`Iter` is a valid :code:`permutation_iterator`
- * :code:`Iter` is a valid :code:`transform_iterator`
- * :code:`Iter` is a valid :code:`counting_iterator`
- * :code:`Iter` is a valid :code:`discard_iterator`
- * :code:`Iter` is a valid :code:`zip_iterator`
+* :code:`Iter` is a random access iterator
+* :code:`Iter` is the unspecified iterator-like type returned by :code:`oneapi::dpl::begin` or :code:`oneapi::dpl::end`
+* :code:`Iter` is a valid :code:`permutation_iterator`
+* :code:`Iter` is a valid :code:`transform_iterator`
+* :code:`Iter` is a valid :code:`counting_iterator`
+* :code:`Iter` is a valid :code:`discard_iterator`
+* :code:`Iter` is a valid :code:`zip_iterator`
 
 .. code:: cpp
 
@@ -237,13 +237,13 @@ iterator instances to determine their position in the index map. :code:`SourceIt
 :code:`ValidParallelIteratorSource`.
 
 The type :code:`IndexMap` must satisfy at least one of the following:
- * :code:`IndexMap` is a random access iterator
- * :code:`IndexMap` is the unspecified iterator-like type returned by :code:`oneapi::dpl::begin` or :code:`oneapi::dpl::end`
- * :code:`IndexMap` is a valid :code:`permutation_iterator`
- * :code:`IndexMap` is a valid :code:`transform_iterator`
- * :code:`IndexMap` is a valid :code:`counting_iterator`
- * :code:`IndexMap` is a functor with a signature equivalent to :code:`T operator()(const T&) const` where
-   :code:`T` is a `std::iterator_traits<SourceIterator>::difference_type`
+* :code:`IndexMap` is a random access iterator
+* :code:`IndexMap` is the unspecified iterator-like type returned by :code:`oneapi::dpl::begin` or :code:`oneapi::dpl::end`
+* :code:`IndexMap` is a valid :code:`permutation_iterator`
+* :code:`IndexMap` is a valid :code:`transform_iterator`
+* :code:`IndexMap` is a valid :code:`counting_iterator`
+* :code:`IndexMap` is a functor with a signature equivalent to :code:`T operator()(const T&) const` where
+  :code:`T` is a `std::iterator_traits<SourceIterator>::difference_type`
 
 
 ``permutation_iterator::operator*`` uses the counter value of the instance on which

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -94,7 +94,7 @@ in ``namespace oneapi::dpl``.
 
 Let us define a named requirement, :code:`AdaptingIteratorSource`, to describe valid random access iterator-like
 types that can be used as source for oneDPL iterators as described below.
-The type :code:`Iter` satisfies the :code:`AdaptingIteratorSource` named requirement if is any of the following:
+The type :code:`Iter` satisfies the :code:`AdaptingIteratorSource` named requirement if it is any of the following:
 
  * a random access iterator
  * the unspecified iterator-like type returned by :code:`oneapi::dpl::begin` or :code:`oneapi::dpl::end`


### PR DESCRIPTION
This PR aims to improve the specification of `permutation_iterator`, `zip_iterator`, and `transform_iterator` by adding requirements for their source iterator types.  

The source iterator type for each of these iterators share the same requirements, for which a name requirement `ValidParallelIteratorSource` has been defined.  There may be a better or more concise name for this requirement.

`permutation_iterator` has a type `IndexMap` which has a modified set of requirements from `ValidParallelIteratorSource`, because some types like `zip_iterator` and `discard_iterator` do not make sense in this setting. Additionally, `IndexMap` can instead be a functor which transforms consecutive indices into a map.  In practice, one implementation of this functionality would be to use a `transform_iterator<counting_iterator, IndexMap>` to provide the iterator serving as the `IndexMap` in a similar way to other incoming `IndexMap` iterators.