### PR TITLE
[oneDPL] Declare predefined `dpcpp_default` policy as `const`

### DIFF
--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -65,7 +65,7 @@ where and how an algorithm runs.
         template <typename KernelName = /*unspecified*/>
         class device_policy;
 
-        inline const device_policy<> dpcpp_default{};
+        const device_policy<> dpcpp_default;
 
         template <typename KernelName = /*unspecified*/>
         device_policy<KernelName>

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -65,7 +65,7 @@ where and how an algorithm runs.
         template <typename KernelName = /*unspecified*/>
         class device_policy;
 
-        inline const device_policy<> dpcpp_default;
+        inline const device_policy<> dpcpp_default{};
 
         template <typename KernelName = /*unspecified*/>
         device_policy<KernelName>

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -65,7 +65,7 @@ where and how an algorithm runs.
         template <typename KernelName = /*unspecified*/>
         class device_policy;
 
-        inline device_policy<> dpcpp_default;
+        inline const device_policy<> dpcpp_default;
 
         template <typename KernelName = /*unspecified*/>
         device_policy<KernelName>

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -65,7 +65,7 @@ where and how an algorithm runs.
         template <typename KernelName = /*unspecified*/>
         class device_policy;
 
-        device_policy<> dpcpp_default;
+        inline device_policy<> dpcpp_default;
 
         template <typename KernelName = /*unspecified*/>
         device_policy<KernelName>


### PR DESCRIPTION
(Edited by @akukanov)
This patch fixes what we consider to be a bug in the oneDPL specification, namely - the predefined `dpcpp_default` execution policy not being `const`.

Since all explicitly specified member functions of the `device_policy` class are `const`, a mutable policy object differs from a non-mutable (`const`) policy object in two ways:
- when an lvalue, it can be a target to assign (i.e. copy or move) another policy object to, changing the associated SYCL queue to the queue associated with the other policy;
- when an rvalue, it can be moved to another policy object, which may invalidate the associated queue and leave the moved-from policy in an unspecified state.

Neither of the above is an appropriate modification for `dpcpp_default`, potentially changing its semantics as a predefined policy associated with the default SYCL device. The possibility of such modifications was previously overlooked and deserves to be fixed.

The change will not impact the ability to pass `dpcpp_default` to oneDPL algorithms, to obtain its associated queue, and to copy or rebind the policy (including using it as the argument to the `make_device_policy` function), which constitute the vast majority of its usages in application codes. Codes that might be broken by the change either do not properly handle any `const` instances of the class or depend on the possibility to modify `dpcpp_default`, which we do not consider as a proper use and want to prevent. In the latter case, a workaround can be to create a copy of `dpcpp_default` and use that instead.