### PR TITLE
Added blocked_rangeNd

### DIFF
--- a/source/elements/oneTBB/source/algorithms.rst
+++ b/source/elements/oneTBB/source/algorithms.rst
@@ -39,6 +39,7 @@ Types that meet the :doc:`Range requirements <named_requirements/algorithms/rang
    algorithms/blocked_ranges/blocked_range_cls.rst
    algorithms/blocked_ranges/blocked_range2d_cls.rst
    algorithms/blocked_ranges/blocked_range3d_cls.rst
+   algorithms/blocked_ranges/blocked_rangeNd_cls.rst
 
 .. _Partitioners:
 

--- a/source/elements/oneTBB/source/algorithms/blocked_ranges/blocked_rangeNd_cls.rst
+++ b/source/elements/oneTBB/source/algorithms/blocked_ranges/blocked_rangeNd_cls.rst
@@ -1,0 +1,153 @@
+.. SPDX-FileCopyrightText: 2019-2021 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
+===============
+blocked_range3d
+===============
+**[algorithms.blocked_range3d]**
+
+Class template that represents a recursively divisible N-dimensional half-open interval.
+
+A ``blocked_rangeNd`` is the N-dimensional extension of ``blocked_range``, ``blocked_range2d`` and ``blocked_range3d``.
+We can interpret it as a tensor-product of N instances of ``blocked_range``.
+Different to ``blocked_range2d`` and ``blocked_range3d``, all ranges have to be specified over the same type Value.
+Therefore, blocked_rangeNd<int,2> is a specialisation of blocked_range2d where both dimensions have int type.
+
+.. code:: cpp
+
+    namespace oneapi {
+        namespace tbb {
+            template<typename Value, unsigned int N, typename = detail::make_index_sequence<N>>
+            class blocked_rangeNd {
+            public:
+                // Types
+                using value_type = Value;
+                using dim_range_type = tbb::blocked_range<Value>;
+
+                // Constructors
+                blocked_rangeNd(const dim_range_type<Is>&... args);
+                blocked_rangeNd(
+                  Value begin[N],
+                  Value end[N],
+                  typename tbb::blocked_range<value_type>::size_type grainsize
+                );
+                blocked_rangeNd(blocked_rangeNd& r, proportional_split proportion); 
+                blocked_rangeNd(blocked_rangeNd& r, split proportion); 
+               
+                // Capacity
+                bool empty() const;
+
+                // Access
+                bool is_divisible() const;
+                static constexpr unsigned int ndims();
+                const tbb::blocked_range<value_type>& dim(unsigned int dimension) const;
+            };
+
+        } // namespace tbb
+    } // namespace oneapi        
+
+Requirements:
+
+* The *Value* must meet the :doc:`blocked_range requirements <../../named_requirements/algorithms/blocked_range_val>`
+
+Member types
+------------
+
+.. code:: cpp
+
+    using value_type = Value;
+
+The type of the page values.
+
+.. code:: cpp
+
+    using page_range_type = blocked_range<PageValue>;
+
+The type of the values in one direction out of the N dimensions.
+
+Member functions
+----------------
+
+.. code:: cpp
+
+    blocked_rangeNd(const dim_range_type<Is>&... args);
+
+**Effects:**  Constructs a ``blocked_rangeNd`` representing an N-dimensional space of values.
+The space is the half-open Cartesian product of ranges each having its own grain size.
+The number of args has to match N.
+
+
+.. code:: cpp
+
+    blocked_rangeNd(
+      Value begin[N],
+      Value end[N],
+      typename tbb::blocked_range<value_type>::size_type grainsize
+    );
+
+**Effects:**  Constructs a ``blocked_rangeNd`` representing an N-dimensional space of values.
+The space is the half-open Cartesian product of ranges with ``[begin[0], end[0]) x [begin[1], end[1]) x ...`` each having the same grain size.
+
+**Example:**  The statement ``blocked_rangeNd<int,4> r( {1,2,3,4}, {5,6,7,8}, 4 );`` constructs a four-dimensional
+space that contains all value pairs of the form ``(i, j, k, l)``, where ``i`` ranges from 1 to 5 with a grain size of 1,
+``j`` ranges from 2 to 6 with a grain size of 1, and so forth.
+    
+
+Basic splitting constructor.
+
+.. code:: cpp
+
+    blocked_rangeNd( blocked_rangeNd& range, split );
+
+Basic splitting constructor.
+
+**Requirements**: ``is_divisible()`` is true.
+
+**Effects**: Partitions ``range`` into two subranges. The newly constructed ``blocked_rangeNd`` is approximately
+the half of the original ``range``, and ``range`` is updated to be the remainder.
+Each subrange has the same grain size as the original ``range``. Splitting is done in any dimension.
+The choice of which axis to split is intended to cause, after repeated splitting, 
+subranges of approximately square/cubic/hypercubic shape if all grain sizes are the same.
+
+.. code:: cpp
+
+    blocked_rangeNd( blocked_range3d& range, proportional_split proportion );
+
+Proportional splitting constructor.
+
+**Requirements**: ``is_divisible()`` is true.
+
+**Effects**: Partitions ``range`` into two subranges in the given ``proportion``
+across one of its axes. The choice of which axis to split is made in the same way as for the basic splitting
+constructor; then, proportional splitting is done for the chosen axis. The second axis and the grain sizes for
+each subrange remain the same as in the original range.
+
+.. code:: cpp
+
+    bool empty() const;
+
+**Effects**: Determines if range is empty.
+
+**Returns:** ``pages.empty()||rows().empty()||cols().empty()``
+
+.. code:: cpp
+
+    bool is_divisible() const;
+
+**Effects**: Determines if the range can be split into subranges.
+
+**Returns:** any dim(int) returns is_divisible().
+
+.. code:: cpp
+
+    const page_range_type& dim(int) const;
+
+**Returns:**  Range containing the range of the value space along axis specified by argument.
+
+See also:
+
+* :doc:`blocked_range <blocked_range_cls>`
+* :doc:`blocked_range2d <blocked_range2d_cls>`
+* :doc:`blocked_range3d <blocked_range3d_cls>`
+


### PR DESCRIPTION
An n-dimensional range has been in Intel's reference implementation for quite a while. It is an absolutely essential feature for a lot of scientific codes and hence should be part of the spec. This proposal starts from Intel's reference implementation but adds an array-based constructor which we found extremely useful in our codes. A PR to the reference implementation is submitted.