### PR TITLE
[oneMKL][spblas] Require same memory kind for alpha and beta parameters

### DIFF
--- a/source/elements/oneMKL/source/domains/spblas/operations/spmm.rst
+++ b/source/elements/oneMKL/source/domains/spblas/operations/spmm.rst
@@ -299,9 +299,9 @@ spmm
       Host or USM pointer representing :math:`\alpha`. The USM allocation can be
       on the host or device. The requirements are:
 
-      * Must use the same kind of memory than ``beta``.
+      * Must use the same kind of memory as ``beta``.
       * Must be a host pointer if SYCL buffers are used.
-      * Must be of the same type than the handles' data type.
+      * Must be of the same type as the handles' data type.
 
    A_view
       Specifies which part of the handle should be read as described by
@@ -317,9 +317,9 @@ spmm
       Host or USM pointer representing :math:`\beta`. The USM allocation can be
       on the host or device. The requirements are:
 
-      * Must use the same kind of memory than ``alpha``.
+      * Must use the same kind of memory as ``alpha``.
       * Must be a host pointer if SYCL buffers are used.
-      * Must be of the same type than the handles' data type.
+      * Must be of the same type as the handles' data type.
 
    C_handle
       Dense matrix handle object representing :math:`C`.

--- a/source/elements/oneMKL/source/domains/spblas/operations/spmm.rst
+++ b/source/elements/oneMKL/source/domains/spblas/operations/spmm.rst
@@ -297,8 +297,11 @@ spmm
 
    alpha
       Host or USM pointer representing :math:`\alpha`. The USM allocation can be
-      on the host or device. Must be a host pointer if SYCL buffers are used.
-      Must be of the same type than the handles' data type.
+      on the host or device. The requirements are:
+
+      * Must use the same kind of memory than ``beta``.
+      * Must be a host pointer if SYCL buffers are used.
+      * Must be of the same type than the handles' data type.
 
    A_view
       Specifies which part of the handle should be read as described by
@@ -312,8 +315,11 @@ spmm
 
    beta
       Host or USM pointer representing :math:`\beta`. The USM allocation can be
-      on the host or device. Must be a host pointer if SYCL buffers are used.
-      Must be of the same type than the handles' data type.
+      on the host or device. The requirements are:
+
+      * Must use the same kind of memory than ``alpha``.
+      * Must be a host pointer if SYCL buffers are used.
+      * Must be of the same type than the handles' data type.
 
    C_handle
       Dense matrix handle object representing :math:`C`.

--- a/source/elements/oneMKL/source/domains/spblas/operations/spmv.rst
+++ b/source/elements/oneMKL/source/domains/spblas/operations/spmv.rst
@@ -289,9 +289,9 @@ spmv
       Host or USM pointer representing :math:`\alpha`. The USM allocation can be
       on the host or device. The requirements are:
 
-      * Must use the same kind of memory than ``beta``.
+      * Must use the same kind of memory as ``beta``.
       * Must be a host pointer if SYCL buffers are used.
-      * Must be of the same type than the handles' data type.
+      * Must be of the same type as the handles' data type.
 
    A_view
       Specifies which part of the handle should be read as described by
@@ -307,9 +307,9 @@ spmv
       Host or USM pointer representing :math:`\beta`. The USM allocation can be
       on the host or device. The requirements are:
 
-      * Must use the same kind of memory than ``alpha``.
+      * Must use the same kind of memory as ``alpha``.
       * Must be a host pointer if SYCL buffers are used.
-      * Must be of the same type than the handles' data type.
+      * Must be of the same type as the handles' data type.
 
    y_handle
       Dense vector handle object representing :math:`y`.

--- a/source/elements/oneMKL/source/domains/spblas/operations/spmv.rst
+++ b/source/elements/oneMKL/source/domains/spblas/operations/spmv.rst
@@ -287,8 +287,11 @@ spmv
 
    alpha
       Host or USM pointer representing :math:`\alpha`. The USM allocation can be
-      on the host or device. Must be a host pointer if SYCL buffers are used.
-      Must be of the same type than the handles' data type.
+      on the host or device. The requirements are:
+
+      * Must use the same kind of memory than ``beta``.
+      * Must be a host pointer if SYCL buffers are used.
+      * Must be of the same type than the handles' data type.
 
    A_view
       Specifies which part of the handle should be read as described by
@@ -302,8 +305,11 @@ spmv
 
    beta
       Host or USM pointer representing :math:`\beta`. The USM allocation can be
-      on the host or device. Must be a host pointer if SYCL buffers are used.
-      Must be of the same type than the handles' data type.
+      on the host or device. The requirements are:
+
+      * Must use the same kind of memory than ``alpha``.
+      * Must be a host pointer if SYCL buffers are used.
+      * Must be of the same type than the handles' data type.
 
    y_handle
       Dense vector handle object representing :math:`y`.

--- a/source/elements/oneMKL/source/domains/spblas/operations/spsv.rst
+++ b/source/elements/oneMKL/source/domains/spblas/operations/spsv.rst
@@ -279,7 +279,7 @@ spsv
    alpha
       Host or USM pointer representing :math:`\alpha`. The USM allocation can be
       on the host or device. Must be a host pointer if SYCL buffers are used.
-      Must be of the same type than the handles' data type.
+      Must be of the same type as the handles' data type.
 
    A_view
       Specifies which part of the handle should be read as described by


### PR DESCRIPTION
Explicitly require the same memory kind of `alpha` and `beta` parameters. Intel oneMKL Product backends require them to be both on the host. [cuSPARSE](https://docs.nvidia.com/cuda/cusparse/index.html#cusparsesetpointermode) and [rocSPARSE](https://rocm.docs.amd.com/projects/rocSPARSE/en/latest/reference/auxiliary.html#rocsparse-set-pointer-mode) backends use a `set_pointer_mode` function which globally set which kind of memory can be used for all the operations thus it is impossible to use different memory kind for these parameters by design.