### PR TITLE
[oneMKL][RNG] Extend parameter type for random distributions

### DIFF
--- a/source/elements/oneMKL/source/domains/rng/host_api/mkl-rng-gaussian_mv.rst
+++ b/source/elements/oneMKL/source/domains/rng/host_api/mkl-rng-gaussian_mv.rst
@@ -26,6 +26,9 @@ The probability density function is given by:
 class gaussian_mv
 -----------------
 
+Let ``SequenceContainerOrView`` be a type that can be one of C++ Sequence containers or C++ Views (``span``, ``mdspan``).
+It's implementation defined which type ``SequenceContainerOrView`` represents.
+
 .. rubric:: Syntax
 
 .. code-block:: cpp
@@ -36,10 +39,10 @@ class gaussian_mv
     public:
         using method_type = Method;
         using result_type = RealType;
-        explicit gaussian_mv(std::uint32_t dimen, std::vector<RealType> mean, std::vector<RealType> matrix);
+        explicit gaussian_mv(std::uint32_t dimen, SequenceContainerOrView<RealType> mean, SequenceContainerOrView<RealType> matrix);
         std::int32_t dimen() const;
-        std::vector<RealType> mean() const;
-        std::vector<RealType> matrix() const;
+        SequenceContainerOrView<RealType> mean() const;
+        SequenceContainerOrView<RealType> matrix() const;
     };
     }
 
@@ -85,13 +88,13 @@ class gaussian_mv
 
         * - Routine
           - Description
-        * - `explicit gaussian_mv(std::uint32_t dimen, std::vector<RealType> mean, std::vector<RealType> matrix)`_
+        * - `explicit gaussian_mv(std::uint32_t dimen, SequenceContainerOrView<RealType> mean, SequenceContainerOrView<RealType> matrix)`_
           - Constructor with parameters
         * - `std::int32_t dimen() const`_
           - Method to obtain number of dimensions in output random vectors
-        * - `std::vector<double> mean() const`_
+        * - `SequenceContainerOrView<double> mean() const`_
           - Method to obtain mean vector `a` of dimension d.
-        * - `std::vector<double> matrix() const`_
+        * - `SequenceContainerOrView<double> matrix() const`_
           - Method to obtain variance-covariance matrix `C`
 
 .. container:: section
@@ -128,17 +131,17 @@ class gaussian_mv
 
     .. container:: section
 
-        .. _`explicit gaussian_mv(std::uint32_t dimen, std::vector<RealType> mean, std::vector<RealType> matrix)`:
+        .. _`explicit gaussian_mv(std::uint32_t dimen, SequenceContainerOrView<RealType> mean, SequenceContainerOrView<RealType> matrix)`:
 
         .. code-block:: cpp
 
-            explicit gaussian_mv::gaussian_mv(std::uint32_t dimen, std::vector<RealType> mean, std::vector<RealType> matrix)
+            explicit gaussian_mv::gaussian_mv(std::uint32_t dimen, SequenceContainerOrView<RealType> mean, SequenceContainerOrView<RealType> matrix)
 
         .. container:: section
 
             .. rubric:: Description
 
-            Constructor with parameters. `dimen` is the number of dimensions, `mean` is a mean vector, `matrix` is a variance-covariance matrix.
+            Constructor with parameters. ``dimen`` is the number of dimensions, ``mean`` is a mean vector, ``matrix`` is a variance-covariance matrix.
 
         .. container:: section
 
@@ -167,11 +170,11 @@ class gaussian_mv
 
     .. container:: section
 
-        .. _`std::vector<double> mean() const`:
+        .. _`SequenceContainerOrView<double> mean() const`:
 
         .. code-block:: cpp
 
-            std::vector<double> gaussian_mv::mean() const
+            SequenceContainerOrView<double> gaussian_mv::mean() const
 
         .. container:: section
 
@@ -181,11 +184,11 @@ class gaussian_mv
 
     .. container:: section
 
-        .. _`std::vector<double> matrix() const`:
+        .. _`SequenceContainerOrView<double> matrix() const`:
 
         .. code-block:: cpp
 
-            std::vector<double> gaussian_mv::matrix() const
+            SequenceContainerOrView<double> gaussian_mv::matrix() const
 
         .. container:: section
 
@@ -193,4 +196,4 @@ class gaussian_mv
 
             Returns the variance-covariance matrix.
 
-**Parent topic:** :ref:`onemkl_rng_distributions`
+**Parent topic:** :ref:`onemkl_rng_distributions`

--- a/source/elements/oneMKL/source/domains/rng/host_api/mkl-rng-multinomial.rst
+++ b/source/elements/oneMKL/source/domains/rng/host_api/mkl-rng-multinomial.rst
@@ -26,6 +26,9 @@ The probability distribution is given by:
 class multinomial
 -----------------
 
+Let ``SequenceContainerOrView`` be a type that can be one of C++ Sequence containers or C++ Views (``span``, ``mdspan``).
+It's implementation defined which type ``SequenceContainerOrView`` represents.
+
 .. rubric:: Syntax
 
 .. code-block:: cpp
@@ -36,9 +39,9 @@ class multinomial
     public:
         using method_type = Method;
         using result_type = IntType;
-        explicit multinomial(double ntrial, std::vector<double> p);
+        explicit multinomial(double ntrial, SequenceContainerOrView<double> p);
         std::int32_t ntrial() const;
-        std::vector<double> p() const;
+        SequenceContainerOrView<double> p() const;
     };
     }
 
@@ -72,12 +75,12 @@ class multinomial
 
         * - Routine
           - Description
-        * - `explicit multinomial(double ntrial, std::vector<double> p)`_
+        * - `explicit multinomial(double ntrial, SequenceContainerOrView<double> p)`_
           - Constructor with parameters
         * - `std::int32_t ntrial() const`_
           - Method to obtain number of independent trials
-        * - `std::vector<double> p() const`_
-          - Method to obtain probability vector of possible outcomes
+        * - `SequenceContainerOrView<double> p() const`_
+          - Method to obtain a probability parameter of possible outcomes
 
 .. container:: section
 
@@ -113,17 +116,17 @@ class multinomial
 
     .. container:: section
 
-        .. _`explicit multinomial(double ntrial, std::vector<double> p)`:
+        .. _`explicit multinomial(double ntrial, SequenceContainerOrView<double> p)`:
 
         .. code-block:: cpp
 
-            explicit multinomial::multinomial(double ntrial, std::vector<double> p)
+            explicit multinomial::multinomial(double ntrial, SequenceContainerOrView<double> p)
 
         .. container:: section
 
             .. rubric:: Description
 
-            Constructor with parameters. `ntrial` is a number of independent trials, `p` is a probability vector.
+            Constructor with parameters. ``ntrial`` is a number of independent trials, ``p`` is a probability parameter.
 
         .. container:: section
 
@@ -152,11 +155,11 @@ class multinomial
 
     .. container:: section
 
-        .. _`std::vector<double> p() const`:
+        .. _`SequenceContainerOrView<double> p() const`:
 
         .. code-block:: cpp
 
-            std::vector<double> multinomial::p() const
+            SequenceContainerOrView<double> multinomial::p() const
 
         .. container:: section
 

--- a/source/elements/oneMKL/source/domains/rng/host_api/mkl-rng-poisson_v.rst
+++ b/source/elements/oneMKL/source/domains/rng/host_api/mkl-rng-poisson_v.rst
@@ -33,8 +33,8 @@ The cumulative distribution function is as follows:
 class poisson_v
 ---------------
 
-Let ``VectorOrSpan`` be a type that can be a ``std::vector`` or ``sycl::span``.
-It's implementation defined which type ``VectorOrSpan`` represents: ``std::vector`` or ``sycl::span``.
+Let ``SequenceContainerOrView`` be a type that can be one of C++ Sequence containers or C++ Views (``span``, ``mdspan``).
+It's implementation defined which type ``SequenceContainerOrView`` represents.
 
 .. rubric:: Syntax
 
@@ -46,8 +46,8 @@ It's implementation defined which type ``VectorOrSpan`` represents: ``std::vecto
     public:
         using method_type = Method;
         using result_type = IntType;
-        explicit poisson_v(VectorOrSpan<double> lambda);
-        VectorOrSpan<double> lambda() const;
+        explicit poisson_v(SequenceContainerOrView<double> lambda);
+        SequenceContainerOrView<double> lambda() const;
     };
     }
 
@@ -80,9 +80,9 @@ It's implementation defined which type ``VectorOrSpan`` represents: ``std::vecto
 
         * - Routine
           - Description
-        * - `explicit poisson_v(VectorOrSpan<double> lambda)`_
+        * - `explicit poisson_v(SequenceContainerOrView<double> lambda)`_
           - Constructor with parameters
-        * - `VectorOrSpan<double> lambda() const`_
+        * - `SequenceContainerOrView<double> lambda() const`_
           - Method to obtain distribution parameter
 
 .. container:: section

--- a/source/elements/oneMKL/source/domains/rng/host_api/mkl-rng-poisson_v.rst
+++ b/source/elements/oneMKL/source/domains/rng/host_api/mkl-rng-poisson_v.rst
@@ -13,7 +13,8 @@ Class is used for generation of Poisson distributed integer types random numbers
 
 .. rubric:: Description
 
-The class object is used in the :ref:`oneapi::mkl::rng::generate()<onemkl_rng_generate>` function to provide n random numbers Poisson distributed, with distribution parameter :math:`\lambda_i`, where :math:`\lambda_i \in R; \lambda_i > 0; i = 1, ... , n`.
+The class object is used in the :ref:`oneapi::mkl::rng::generate()<onemkl_rng_generate>` function to provide
+n random numbers Poisson distributed, with distribution parameter :math:`\lambda_i`, where :math:`\lambda_i \in R; \lambda_i > 0; i = 1, ... , n`.
 
 The probability distribution is given by:
 
@@ -32,8 +33,8 @@ The cumulative distribution function is as follows:
 class poisson_v
 ---------------
 
-Let `VectorOrSpan` be a type that can be a `std::vector` or `sycl::span`.
-It's implementation defined which type `VectorOrSpan` represents: `std::vector` or `sycl::span`.
+Let ``VectorOrSpan`` be a type that can be a ``std::vector`` or ``sycl::span``.
+It's implementation defined which type ``VectorOrSpan`` represents: ``std::vector`` or ``sycl::span``.
 
 .. rubric:: Syntax
 

--- a/source/elements/oneMKL/source/domains/rng/host_api/mkl-rng-poisson_v.rst
+++ b/source/elements/oneMKL/source/domains/rng/host_api/mkl-rng-poisson_v.rst
@@ -119,17 +119,17 @@ It's implementation defined which type ``SequenceContainerOrView`` represents.
 
     .. container:: section
 
-        .. _`explicit poisson_v(std::vector<double> lambda)`:
+        .. _`explicit poisson_v(SequenceContainerOrView<double> lambda)`:
 
         .. code-block:: cpp
 
-            explicit poisson_v::poisson_v(std::vector<double> lambda)
+            explicit poisson_v::poisson_v(SequenceContainerOrView<double> lambda)
 
         .. container:: section
 
             .. rubric:: Description
 
-            Constructor with parameters. `lambda` is a distribution parameter.
+            Constructor with parameters. ``lambda`` is a distribution parameter.
 
         .. container:: section
 
@@ -144,16 +144,16 @@ It's implementation defined which type ``SequenceContainerOrView`` represents.
 
     .. container:: section
 
-        .. _`std::vector<double> lambda() const`:
+        .. _`SequenceContainerOrView<double> lambda() const`:
 
         .. code-block:: cpp
 
-            double poisson_v::lambda() const
+            SequenceContainerOrView<double> poisson_v::lambda() const
 
         .. container:: section
 
             .. rubric:: Return Value
 
-            Returns the distribution parameter `lambda`.
+            Returns the distribution parameter ``lambda``.
 
-**Parent topic:** :ref:`onemkl_rng_distributions`
+**Parent topic:** :ref:`onemkl_rng_distributions`

--- a/source/elements/oneMKL/source/domains/rng/host_api/mkl-rng-poisson_v.rst
+++ b/source/elements/oneMKL/source/domains/rng/host_api/mkl-rng-poisson_v.rst
@@ -32,6 +32,9 @@ The cumulative distribution function is as follows:
 class poisson_v
 ---------------
 
+Let `VectorOrSpan` be a type that can be a `std::vector` or `sycl::span`.
+It's implementation defined which type `VectorOrSpan` represents: `std::vector` or `sycl::span`.
+
 .. rubric:: Syntax
 
 .. code-block:: cpp
@@ -42,8 +45,8 @@ class poisson_v
     public:
         using method_type = Method;
         using result_type = IntType;
-        explicit poisson_v(std::vector<double> lambda);
-        std::vector<double> lambda() const;
+        explicit poisson_v(VectorOrSpan<double> lambda);
+        VectorOrSpan<double> lambda() const;
     };
     }
 
@@ -76,9 +79,9 @@ class poisson_v
 
         * - Routine
           - Description
-        * - `explicit poisson_v(std::vector<double> lambda)`_
+        * - `explicit poisson_v(VectorOrSpan<double> lambda)`_
           - Constructor with parameters
-        * - `std::vector<double> lambda() const`_
+        * - `VectorOrSpan<double> lambda() const`_
           - Method to obtain distribution parameter
 
 .. container:: section


### PR DESCRIPTION
It was found that it's not necessary to make implementors use `std::vector` as a parameter type for `gaussian_mv`, `multinomial`, `poisson_v` distributions. They can also use `std::array` or `std::view` for example to pass data to distribution. This PR relaxes requirement for such parameter types.

Feel free to share your feedback