### PR TITLE
[RNG] Updating device-rng-bernoulli.rst on small types support

### DIFF
--- a/source/elements/oneMKL/source/domains/rng/device_api/device-rng-bernoulli.rst
+++ b/source/elements/oneMKL/source/domains/rng/device_api/device-rng-bernoulli.rst
@@ -67,6 +67,10 @@ class bernoulli
 
         typename IntType
             Type of the produced values. Supported types:
+                * ``std::int8_t``
+                * ``std::uint8_t``
+                * ``std::int16_t``
+                * ``std::uint16_t``
                 * ``std::int32_t``
                 * ``std::uint32_t``
 


### PR DESCRIPTION
New supported types for Bernoulli distr have been added