### PR TITLE
[oneDPL] Sort By Key APIs

### DIFF
--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -697,7 +697,7 @@ The elements e of [start, end) must be partitioned with respect to the comparato
         InputValueIt values_first,
         Comparator comp = std::less<typename std::iterator_traits<InputIt>::value_type>{});
 
-``oneapi::dpl::sort_by_key`` sorts a sequence of keys in the range ``[keys_first, keys_last)``,
+``oneapi::dpl::sort_by_key`` sorts a sequence of keys in the range ``[keys_first, keys_last)``
 and simultaneously permutes associated values at the same positions in the range
 ``[values_first, values_first + std::distance(keys_first, keys_last))``
 to match the order of the sorted keys.
@@ -705,8 +705,9 @@ to match the order of the sorted keys.
 Sorting is unstable. That means, keys that do not precede one another according to the given comparator
 and their associated values might be ordered arbitrarily relative to each other.
 
-`comp`` is a function object that satisfies the requirements defined by the `C++ Standard`_
-for the equivalent parameter of `std::sort`.
+``comp`` is a function object that satisfies the requirements defined by the `C++ Standard`_
+for the equivalent parameter of ``std::sort``.
+If no ``comp`` object is provided, the keys are sorted with respect to ``std::less``.
 
 .. code:: cpp
 
@@ -717,7 +718,7 @@ for the equivalent parameter of `std::sort`.
         InputValueIt values_first,
         Comparator comp = std::less<typename std::iterator_traits<InputIt>::value_type>());
 
-``oneapi::dpl::stable_sort_by_key`` sorts a sequence of keys in the range ``[keys_first, keys_last)``,
+``oneapi::dpl::stable_sort_by_key`` sorts a sequence of keys in the range ``[keys_first, keys_last)``
 and simultaneously permutes associated values at the same positions in the range
 ``[values_first, values_first + std::distance(keys_first, keys_last))``
 to match the order of the sorted keys.
@@ -725,8 +726,9 @@ to match the order of the sorted keys.
 Sorting is stable. That means, keys that do not precede one another according to the given comparator
 and their associated values maintain their relative order as in the original sequences.
 
-`comp`` is a function object that satisfies the requirements defined by the `C++ Standard`_
-for the equivalent parameter of `std::sort`.
+``comp`` is a function object that satisfies the requirements defined by the `C++ Standard`_
+for the equivalent parameter of ``std::sort``.
+If no ``comp`` object is provided, the keys are sorted with respect to ``std::less``.
 
 .. _`C++ Standard`: https://isocpp.org/std/the-standard
 .. _`SYCL`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -698,11 +698,10 @@ The elements e of [start, end) must be partitioned with respect to the comparato
                 InputValueIt values_first, Comparator comp =
                     std::less<typename std::iterator_traits<InputKeyIt>::value_type>());
 
-``oneapi::dpl::sort_by_key`` sorts a sequence of keys within the range ``[keys_first, keys_last)``.
-It also permutes the corresponding sequence of values within the range
-``[values_first, values_first + distance(keys_first, keys_last))``.
-Each key is associated with a corresponding value,
-and this association is maintained throughout the sorting process.
+``oneapi::dpl::sort_by_key`` sorts a sequence of keys in the range ``[keys_first, keys_last)``,
+and simultaneously permutes associated values at the same positions in the range
+``[values_first, values_first + std::distance(keys_first, keys_last))``
+to match the order of the sorted keys.
 
 The order of equal keys is not guaranteed to be preserved.
 
@@ -720,11 +719,10 @@ If no ``comp`` object is provided, the keys are sorted with respect to ``std::le
                 InputValueIt values_first, Comparator comp =
                     std::less<typename std::iterator_traits<InputKeyIt>::value_type>());
 
-``oneapi::dpl::stable_sort_by_key`` sorts a sequence of keys within the range ``[keys_first, keys_last)``.
-It also permutes the corresponding sequence of values within the range
-``[values_first, values_first + distance(keys_first, keys_last))``.
-Each key is associated with a corresponding value,
-and this association is maintained throughout the sorting process.
+``oneapi::dpl::stable_sort_by_key`` sorts a sequence of keys in the range ``[keys_first, keys_last)``,
+and simultaneously permutes associated values at the same positions in the range
+``[values_first, values_first + std::distance(keys_first, keys_last))``
+to match the order of the sorted keys.
 
 The order of equal keys is preserved.
 

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -690,11 +690,11 @@ The elements e of [start, end) must be partitioned with respect to the comparato
 
 .. code:: cpp
 
-    template<typename Policy, typename InputKeyIt, typename InputValueIt,
+    template<typename Policy, typename KeyIt, typename ValueIt,
         typename Comparator = std::less<typename std::iterator_traits<InputIt>::value_type>>
     void
-    sort_by_key(Policy&& policy, InputKeyIt keys_first, InputKeyIt keys_last,
-        InputValueIt values_first,
+    sort_by_key(Policy&& policy, KeyIt keys_first, KeyIt keys_last,
+        ValueIt values_first,
         Comparator comp = std::less<typename std::iterator_traits<InputIt>::value_type>());
 
 ``oneapi::dpl::sort_by_key`` sorts the sequence of keys ``[keys_first, keys_last)``
@@ -710,17 +710,17 @@ If no ``comp`` object is provided, keys are sorted with respect to ``std::less``
 Sorting is unstable. That means, keys, which do not precede one another with respect to the given 
 comparator, and their associated values might be ordered arbitrarily relative to each other.
 
-``InputKeyIt`` and ``InputValueIt`` must satisfy the requirements of ``ValueSwappable``,
+``KeyIt`` and ``ValueIt`` must satisfy the requirements of ``ValueSwappable``,
 and ``Comparator`` must satisfy the requirements for the ``Compare`` parameter of ``std::sort``,
 as defined by the `C++ Standard`_.
 
 .. code:: cpp
 
-    template<typename Policy, typename InputKeyIt, typename InputValueIt,
+    template<typename Policy, typename KeyIt, typename ValueIt,
         typename Comparator = std::less<typename std::iterator_traits<InputIt>::value_type>>
     void
-    stable_sort_by_key(Policy&& policy, InputKeyIt keys_first, InputKeyIt keys_last,
-        InputValueIt values_first,
+    stable_sort_by_key(Policy&& policy, KeyIt keys_first, KeyIt keys_last,
+        ValueIt values_first,
         Comparator comp = std::less<typename std::iterator_traits<InputIt>::value_type>());
 
 ``oneapi::dpl::stable_sort_by_key`` sorts the sequence of keys ``[keys_first, keys_last)``
@@ -736,7 +736,7 @@ If no ``comp`` object is provided, keys are sorted with respect to ``std::less``
 Sorting is stable. That means, keys, which do not precede one another with respect to the given 
 comparator, and their associated values maintain the relative order as in the original sequences.
 
-``InputKeyIt`` and ``InputValueIt`` must satisfy the requirements of ``ValueSwappable``,
+``KeyIt`` and ``ValueIt`` must satisfy the requirements of ``ValueSwappable``,
 and ``Comparator`` must satisfy the requirements for the ``Compare`` parameter of ``std::sort``,
 as defined by the `C++ Standard`_.
 

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -698,12 +698,12 @@ The elements e of [start, end) must be partitioned with respect to the comparato
                 InputValueIt values_first, Comparator comp =
                     std::less<typename std::iterator_traits<InputKeyIt>::value_type>());
 
-:code:`oneapi::dpl::sort_by_key` sorts a sequence of keys in the range :code:`[keys_first, keys_last)`,
+``oneapi::dpl::sort_by_key`` sorts a sequence of keys in the range ``[keys_first, keys_last)``,
 and permutes a sequence of values in the range
-:code:`[values_first, values_first + distance(keys_first, keys_last))` to match the order of the sorted keys.
+``[values_first, values_first + distance(keys_first, keys_last))`` to match the order of the sorted keys.
 The order of equal keys is not guaranteed to be preserved.
 
-If no comparator is provided, the keys are sorted with respect to :code:`std::less{}`.
+If no comparator is provided, the keys are sorted with respect to ``std::less{}``.
 
 .. code:: cpp
 
@@ -715,12 +715,12 @@ If no comparator is provided, the keys are sorted with respect to :code:`std::le
                 InputValueIt values_first, Comparator comp =
                     std::less<typename std::iterator_traits<InputKeyIt>::value_type>());
 
-:code:`oneapi::dpl::stable_sort_by_key` sorts a sequence of keys in the range :code:`[keys_first, keys_last)`,
+``oneapi::dpl::stable_sort_by_key`` sorts a sequence of keys in the range ``[keys_first, keys_last)``,
 and permutes a sequence of values in the range
-:code:`[values_first, values_first + distance(keys_first, keys_last))` to match the order of the sorted keys.
+``[values_first, values_first + distance(keys_first, keys_last))`` to match the order of the sorted keys.
 The order of equal keys is preserved.
 
-If no comparator is provided, the keys are sorted with respect to :code:`std::less{}`.
+If no comparator is provided, the keys are sorted with respect to ``std::less{}``.
 
 .. _`C++ Standard`: https://isocpp.org/std/the-standard
 .. _`SYCL`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -698,9 +698,9 @@ The elements e of [start, end) must be partitioned with respect to the comparato
                 InputValueIt values_first, Comparator comp =
                     std::less<typename std::iterator_traits<InputKeyIt>::value_type>());
 
-:code:`oneapi::dpl::sort_by_key` sorts a sequence of keys in the range :code:`[keys_first, keys_last)`
-and permutes a sequnce of values in the range
-:code:`[values_first, values_first + distance(keys_first, keys_last))` according to the sorted order of the keys.
+:code:`oneapi::dpl::sort_by_key` sorts a sequence of keys in the range :code:`[keys_first, keys_last)`,
+and permutes a sequence of values in the range
+:code:`[values_first, values_first + distance(keys_first, keys_last))` to match the order of the sorted keys.
 The order of equal keys is not guaranteed to be preserved.
 
 If no comparator is provided, the keys are sorted with respect to :code:`std::less{}`.
@@ -715,9 +715,9 @@ If no comparator is provided, the keys are sorted with respect to :code:`std::le
                 InputValueIt values_first, Comparator comp =
                     std::less<typename std::iterator_traits<InputKeyIt>::value_type>());
 
-:code:`oneapi::dpl::stable_sort_by_key` sorts a sequence of keys in the range :code:`[keys_first, keys_last)`
-and permutes a sequnce of values in the range
-:code:`[values_first, values_first + distance(keys_first, keys_last))` according to the sorted order of the keys.
+:code:`oneapi::dpl::stable_sort_by_key` sorts a sequence of keys in the range :code:`[keys_first, keys_last)`,
+and permutes a sequence of values in the range
+:code:`[values_first, values_first + distance(keys_first, keys_last))` to match the order of the sorted keys.
 The order of equal keys is guaranteed to be preserved.
 
 If no comparator is provided, the keys are sorted with respect to :code:`std::less{}`.

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -705,9 +705,8 @@ to match the order of the sorted keys.
 
 The order of equal keys is not guaranteed to be preserved.
 
-``comp`` is a function object,
-which satisfies the ``Compare`` named requirement defined by the `C++ Standard`_.
-If no ``comp`` object is provided, the keys are sorted with respect to ``std::less{}``.
+`comp`` is a function object that satisfies the requirements defined by the `C++ Standard`_
+for the equivalent parameter of `std::sort`.
 
 .. code:: cpp
 
@@ -726,9 +725,8 @@ to match the order of the sorted keys.
 
 The order of equal keys is preserved.
 
-``comp`` is a function object,
-which satisfies the ``Compare`` named requirement defined by the `C++ Standard`_.
-If no ``comp`` object is provided, the keys are sorted with respect to ``std::less{}``.
+`comp`` is a function object that satisfies the requirements defined by the `C++ Standard`_
+for the equivalent parameter of `std::sort`.
 
 .. _`C++ Standard`: https://isocpp.org/std/the-standard
 .. _`SYCL`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -698,9 +698,12 @@ The elements e of [start, end) must be partitioned with respect to the comparato
                 InputValueIt values_first, Comparator comp =
                     std::less<typename std::iterator_traits<InputKeyIt>::value_type>());
 
-``oneapi::dpl::sort_by_key`` sorts a sequence of keys in the range ``[keys_first, keys_last)``,
-and permutes a sequence of values in the range
-``[values_first, values_first + distance(keys_first, keys_last))`` to match the order of the sorted keys.
+``oneapi::dpl::sort_by_key`` sorts a sequence of keys within the range ``[keys_first, keys_last)``.
+It also permutes the corresponding sequence of values within the range
+``[values_first, values_first + distance(keys_first, keys_last))``.
+Each key is associated with a corresponding value,
+and this association is maintained throughout the sorting process.
+
 The order of equal keys is not guaranteed to be preserved.
 
 If no comparator is provided, the keys are sorted with respect to ``std::less{}``.
@@ -715,9 +718,12 @@ If no comparator is provided, the keys are sorted with respect to ``std::less{}`
                 InputValueIt values_first, Comparator comp =
                     std::less<typename std::iterator_traits<InputKeyIt>::value_type>());
 
-``oneapi::dpl::stable_sort_by_key`` sorts a sequence of keys in the range ``[keys_first, keys_last)``,
-and permutes a sequence of values in the range
-``[values_first, values_first + distance(keys_first, keys_last))`` to match the order of the sorted keys.
+``oneapi::dpl::stable_sort_by_key`` sorts a sequence of keys within the range ``[keys_first, keys_last)``.
+It also permutes the corresponding sequence of values within the range
+``[values_first, values_first + distance(keys_first, keys_last))``.
+Each key is associated with a corresponding value,
+and this association is maintained throughout the sorting process.
+
 The order of equal keys is preserved.
 
 If no comparator is provided, the keys are sorted with respect to ``std::less{}``.

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -705,6 +705,9 @@ to match the order of the sorted keys.
 Sorting is unstable. That means, keys that do not precede one another according to the given comparator
 and their associated values might be ordered arbitrarily relative to each other.
 
+`InputKeyIt` and `InputValueIt` must meet the requirements of
+`ValueSwappable` defined by the `C++ Standard`_.
+
 ``comp`` is a function object that satisfies the requirements defined by the `C++ Standard`_
 for the ``Compare`` parameter of ``std::sort``.
 If no ``comp`` object is provided, the keys are sorted with respect to ``std::less``.
@@ -725,6 +728,9 @@ to match the order of the sorted keys.
 
 Sorting is stable. That means, keys that do not precede one another according to the given comparator
 and their associated values maintain their relative order as in the original sequences.
+
+`InputKeyIt` and `InputValueIt` must meet the requirements of
+`ValueSwappable` defined by the `C++ Standard`_.
 
 ``comp`` is a function object that satisfies the requirements defined by the `C++ Standard`_
 for the ``Compare`` parameter of ``std::sort``.

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -708,8 +708,8 @@ two iterators ``i`` and ``j`` to the sorted sequence of keys such that ``i`` pre
 ``comp(*j, *i) == false``.
 If no ``comp`` object is provided, keys are sorted with respect to ``std::less``.
 
-Sorting is unstable. That means, keys, which do not precede one another with respect to the given
-comparator, and their associated values might be ordered arbitrarily relative to each other.
+Sorting is unstable. That means, keys which do not precede one another with respect to the given
+comparator and their associated values might be ordered arbitrarily relative to each other.
 
 ``KeyIt`` and ``ValueIt`` must satisfy the requirements of ``ValueSwappable``,
 and ``Comparator`` must satisfy the requirements for the ``Compare`` parameter of ``std::sort``,
@@ -735,8 +735,8 @@ two iterators ``i`` and ``j`` to the sorted sequence of keys such that ``i`` pre
 ``comp(*j, *i) == false``.
 If no ``comp`` object is provided, keys are sorted with respect to ``std::less``.
 
-Sorting is stable. That means, keys, which do not precede one another with respect to the given
-comparator, and their associated values maintain the relative order as in the original sequences.
+Sorting is stable. That means, keys which do not precede one another with respect to the given
+comparator and their associated values maintain the relative order as in the original sequences.
 
 ``KeyIt`` and ``ValueIt`` must satisfy the requirements of ``ValueSwappable``,
 and ``Comparator`` must satisfy the requirements for the ``Compare`` parameter of ``std::sort``,

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -508,7 +508,6 @@ satisfy a given predicate, and stores the result to the output. Depending on the
    modified from its initial value. The return value is an iterator targeting past the last
    considered element of the output sequence, that is, ``result + (end1 - start1)``.
 
-
 .. code:: cpp
 
     template<typename Policy, typename KeyIt, typename ValueIt,

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -691,11 +691,11 @@ The elements e of [start, end) must be partitioned with respect to the comparato
 .. code:: cpp
 
     template<typename Policy, typename KeyIt, typename ValueIt,
-        typename Comparator = std::less<typename std::iterator_traits<InputIt>::value_type>>
+        typename Comparator = std::less<typename std::iterator_traits<KeyIt>::value_type>>
     void
     sort_by_key(Policy&& policy, KeyIt keys_first, KeyIt keys_last,
         ValueIt values_first,
-        Comparator comp = std::less<typename std::iterator_traits<InputIt>::value_type>());
+        Comparator comp = std::less<typename std::iterator_traits<KeyIt>::value_type>());
 
 ``oneapi::dpl::sort_by_key`` sorts the sequence of keys ``[keys_first, keys_last)``
 and simultaneously permutes associated values at the same positions in the range
@@ -718,11 +718,11 @@ as defined by the `C++ Standard`_.
 .. code:: cpp
 
     template<typename Policy, typename KeyIt, typename ValueIt,
-        typename Comparator = std::less<typename std::iterator_traits<InputIt>::value_type>>
+        typename Comparator = std::less<typename std::iterator_traits<KeyIt>::value_type>>
     void
     stable_sort_by_key(Policy&& policy, KeyIt keys_first, KeyIt keys_last,
         ValueIt values_first,
-        Comparator comp = std::less<typename std::iterator_traits<InputIt>::value_type>());
+        Comparator comp = std::less<typename std::iterator_traits<KeyIt>::value_type>());
 
 ``oneapi::dpl::stable_sort_by_key`` sorts the sequence of keys ``[keys_first, keys_last)``
 and simultaneously permutes associated values at the same positions in the range

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -718,7 +718,7 @@ If no comparator is provided, the keys are sorted with respect to :code:`std::le
 :code:`oneapi::dpl::stable_sort_by_key` sorts a sequence of keys in the range :code:`[keys_first, keys_last)`,
 and permutes a sequence of values in the range
 :code:`[values_first, values_first + distance(keys_first, keys_last))` to match the order of the sorted keys.
-The order of equal keys is guaranteed to be preserved.
+The order of equal keys is preserved.
 
 If no comparator is provided, the keys are sorted with respect to :code:`std::less{}`.
 

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -695,7 +695,7 @@ The elements e of [start, end) must be partitioned with respect to the comparato
     void
     sort_by_key(Policy&& policy, InputKeyIt keys_first, InputKeyIt keys_last,
         InputValueIt values_first,
-        Comparator comp = std::less<typename std::iterator_traits<InputIt>::value_type>{});
+        Comparator comp = std::less<typename std::iterator_traits<InputIt>::value_type>());
 
 ``oneapi::dpl::sort_by_key`` sorts a sequence of keys in the range ``[keys_first, keys_last)``
 and simultaneously permutes associated values at the same positions in the range

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -703,7 +703,7 @@ and permutes a sequnce of values in the range
 :code:`[values_first, values_first + distance(keys_first, keys_last))` according to the sorted order of the keys.
 The order of equal keys is not guaranteed to be preserved.
 
-If no comparator is provided, the keys are sorted with respect to :code:`std::less`.
+If no comparator is provided, the keys are sorted with respect to :code:`std::less{}`.
 
 .. code:: cpp
 
@@ -720,7 +720,7 @@ and permutes a sequnce of values in the range
 :code:`[values_first, values_first + distance(keys_first, keys_last))` according to the sorted order of the keys.
 The order of equal keys is guaranteed to be preserved.
 
-If no comparator is provided, the keys are sorted with respect to :code:`std::less`.
+If no comparator is provided, the keys are sorted with respect to :code:`std::less{}`.
 
 .. _`C++ Standard`: https://isocpp.org/std/the-standard
 .. _`SYCL`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -706,7 +706,9 @@ and this association is maintained throughout the sorting process.
 
 The order of equal keys is not guaranteed to be preserved.
 
-If no comparator is provided, the keys are sorted with respect to ``std::less{}``.
+``comp`` is a function object,
+which satisfies the ``Compare`` named requirement defined by the `C++ Standard`_.
+If no ``comp`` object is provided, the keys are sorted with respect to ``std::less{}``.
 
 .. code:: cpp
 
@@ -726,7 +728,9 @@ and this association is maintained throughout the sorting process.
 
 The order of equal keys is preserved.
 
-If no comparator is provided, the keys are sorted with respect to ``std::less{}``.
+``comp`` is a function object,
+which satisfies the ``Compare`` named requirement defined by the `C++ Standard`_.
+If no ``comp`` object is provided, the keys are sorted with respect to ``std::less{}``.
 
 .. _`C++ Standard`: https://isocpp.org/std/the-standard
 .. _`SYCL`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -705,8 +705,8 @@ to match the order of the sorted keys.
 Sorting is unstable. That means, keys that do not precede one another according to the given comparator
 and their associated values might be ordered arbitrarily relative to each other.
 
-`InputKeyIt` and `InputValueIt` must meet the requirements of
-`ValueSwappable` defined by the `C++ Standard`_.
+``InputKeyIt`` and ``InputValueIt`` must meet the requirements of
+``ValueSwappable`` defined by the `C++ Standard`_.
 
 ``comp`` is a function object that satisfies the requirements defined by the `C++ Standard`_
 for the ``Compare`` parameter of ``std::sort``.
@@ -729,8 +729,8 @@ to match the order of the sorted keys.
 Sorting is stable. That means, keys that do not precede one another according to the given comparator
 and their associated values maintain their relative order as in the original sequences.
 
-`InputKeyIt` and `InputValueIt` must meet the requirements of
-`ValueSwappable` defined by the `C++ Standard`_.
+``InputKeyIt`` and ``InputValueIt`` must meet the requirements of
+``ValueSwappable`` defined by the `C++ Standard`_.
 
 ``comp`` is a function object that satisfies the requirements defined by the `C++ Standard`_
 for the ``Compare`` parameter of ``std::sort``.

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -700,14 +700,15 @@ The elements e of [start, end) must be partitioned with respect to the comparato
 ``oneapi::dpl::sort_by_key`` sorts the sequence of keys ``[keys_first, keys_last)``
 and simultaneously permutes associated values at the same positions in the range
 ``[values_first, values_first + std::distance(keys_first, keys_last))``
-to match the order of the sorted keys.
+to match the order of the sorted keys. That is, a key and its associated value
+will have the same index in their respective sequences after sorting.
 
 Keys are sorted with respect to the provided comparator object ``comp``. That means, for any
 two iterators ``i`` and ``j`` to the sorted sequence of keys such that ``i`` precedes ``j``,
 ``comp(*j, *i) == false``.
 If no ``comp`` object is provided, keys are sorted with respect to ``std::less``.
 
-Sorting is unstable. That means, keys, which do not precede one another with respect to the given 
+Sorting is unstable. That means, keys, which do not precede one another with respect to the given
 comparator, and their associated values might be ordered arbitrarily relative to each other.
 
 ``KeyIt`` and ``ValueIt`` must satisfy the requirements of ``ValueSwappable``,
@@ -726,14 +727,15 @@ as defined by the `C++ Standard`_.
 ``oneapi::dpl::stable_sort_by_key`` sorts the sequence of keys ``[keys_first, keys_last)``
 and simultaneously permutes associated values at the same positions in the range
 ``[values_first, values_first + std::distance(keys_first, keys_last))``
-to match the order of the sorted keys.
+to match the order of the sorted keys. That is, a key and its associated value
+will have the same index in their respective sequences after sorting.
 
 Keys are sorted with respect to the provided comparator object ``comp``. That means, for any
 two iterators ``i`` and ``j`` to the sorted sequence of keys such that ``i`` precedes ``j``,
 ``comp(*j, *i) == false``.
 If no ``comp`` object is provided, keys are sorted with respect to ``std::less``.
 
-Sorting is stable. That means, keys, which do not precede one another with respect to the given 
+Sorting is stable. That means, keys, which do not precede one another with respect to the given
 comparator, and their associated values maintain the relative order as in the original sequences.
 
 ``KeyIt`` and ``ValueIt`` must satisfy the requirements of ``ValueSwappable``,

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -697,20 +697,22 @@ The elements e of [start, end) must be partitioned with respect to the comparato
         InputValueIt values_first,
         Comparator comp = std::less<typename std::iterator_traits<InputIt>::value_type>());
 
-``oneapi::dpl::sort_by_key`` sorts a sequence of keys in the range ``[keys_first, keys_last)``
+``oneapi::dpl::sort_by_key`` sorts the sequence of keys ``[keys_first, keys_last)``
 and simultaneously permutes associated values at the same positions in the range
 ``[values_first, values_first + std::distance(keys_first, keys_last))``
 to match the order of the sorted keys.
 
-Sorting is unstable. That means, keys that do not precede one another according to the given comparator
-and their associated values might be ordered arbitrarily relative to each other.
+Keys are sorted with respect to the provided comparator object ``comp``. That means, for any
+two iterators ``i`` and ``j`` to the sorted sequence of keys such that ``i`` precedes ``j``,
+``comp(*j, *i) == false``.
+If no ``comp`` object is provided, keys are sorted with respect to ``std::less``.
 
-``InputKeyIt`` and ``InputValueIt`` must meet the requirements of
-``ValueSwappable`` defined by the `C++ Standard`_.
+Sorting is unstable. That means, keys, which do not precede one another with respect to the given 
+comparator, and their associated values might be ordered arbitrarily relative to each other.
 
-``comp`` is a function object that satisfies the requirements defined by the `C++ Standard`_
-for the ``Compare`` parameter of ``std::sort``.
-If no ``comp`` object is provided, the keys are sorted with respect to ``std::less``.
+``InputKeyIt`` and ``InputValueIt`` must satisfy the requirements of ``ValueSwappable``,
+and ``Comparator`` must satisfy the requirements for the ``Compare`` parameter of ``std::sort``,
+as defined by the `C++ Standard`_.
 
 .. code:: cpp
 
@@ -721,20 +723,22 @@ If no ``comp`` object is provided, the keys are sorted with respect to ``std::le
         InputValueIt values_first,
         Comparator comp = std::less<typename std::iterator_traits<InputIt>::value_type>());
 
-``oneapi::dpl::stable_sort_by_key`` sorts a sequence of keys in the range ``[keys_first, keys_last)``
+``oneapi::dpl::stable_sort_by_key`` sorts the sequence of keys ``[keys_first, keys_last)``
 and simultaneously permutes associated values at the same positions in the range
 ``[values_first, values_first + std::distance(keys_first, keys_last))``
 to match the order of the sorted keys.
 
-Sorting is stable. That means, keys that do not precede one another according to the given comparator
-and their associated values maintain their relative order as in the original sequences.
+Keys are sorted with respect to the provided comparator object ``comp``. That means, for any
+two iterators ``i`` and ``j`` to the sorted sequence of keys such that ``i`` precedes ``j``,
+``comp(*j, *i) == false``.
+If no ``comp`` object is provided, keys are sorted with respect to ``std::less``.
 
-``InputKeyIt`` and ``InputValueIt`` must meet the requirements of
-``ValueSwappable`` defined by the `C++ Standard`_.
+Sorting is stable. That means, keys, which do not precede one another with respect to the given 
+comparator, and their associated values maintain the relative order as in the original sequences.
 
-``comp`` is a function object that satisfies the requirements defined by the `C++ Standard`_
-for the ``Compare`` parameter of ``std::sort``.
-If no ``comp`` object is provided, the keys are sorted with respect to ``std::less``.
+``InputKeyIt`` and ``InputValueIt`` must satisfy the requirements of ``ValueSwappable``,
+and ``Comparator`` must satisfy the requirements for the ``Compare`` parameter of ``std::sort``,
+as defined by the `C++ Standard`_.
 
 .. _`C++ Standard`: https://isocpp.org/std/the-standard
 .. _`SYCL`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -691,12 +691,11 @@ The elements e of [start, end) must be partitioned with respect to the comparato
 .. code:: cpp
 
     template<typename Policy, typename InputKeyIt, typename InputValueIt,
-        typename Comparator =
-            std::less<typename std::iterator_traits<InputIt>::value_type>>
+        typename Comparator = std::less<typename std::iterator_traits<InputIt>::value_type>>
     void
     sort_by_key(Policy&& policy, InputKeyIt keys_first, InputKeyIt keys_last,
-                InputValueIt values_first, Comparator comp =
-                    std::less<typename std::iterator_traits<InputKeyIt>::value_type>());
+        InputValueIt values_first,
+        Comparator comp = std::less<typename std::iterator_traits<InputIt>::value_type>{});
 
 ``oneapi::dpl::sort_by_key`` sorts a sequence of keys in the range ``[keys_first, keys_last)``,
 and simultaneously permutes associated values at the same positions in the range
@@ -712,12 +711,11 @@ for the equivalent parameter of `std::sort`.
 .. code:: cpp
 
     template<typename Policy, typename InputKeyIt, typename InputValueIt,
-      typename Comparator =
-          std::less<typename std::iterator_traits<InputIt>::value_type>>
+        typename Comparator = std::less<typename std::iterator_traits<InputIt>::value_type>>
     void
     stable_sort_by_key(Policy&& policy, InputKeyIt keys_first, InputKeyIt keys_last,
-                InputValueIt values_first, Comparator comp =
-                    std::less<typename std::iterator_traits<InputKeyIt>::value_type>());
+        InputValueIt values_first,
+        Comparator comp = std::less<typename std::iterator_traits<InputIt>::value_type>());
 
 ``oneapi::dpl::stable_sort_by_key`` sorts a sequence of keys in the range ``[keys_first, keys_last)``,
 and simultaneously permutes associated values at the same positions in the range

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -703,7 +703,8 @@ and simultaneously permutes associated values at the same positions in the range
 ``[values_first, values_first + std::distance(keys_first, keys_last))``
 to match the order of the sorted keys.
 
-The order of equal keys is not guaranteed to be preserved.
+Sorting is unstable. That means, keys that do not precede one another according to the given comparator
+and their associated values might be ordered arbitrarily relative to each other.
 
 `comp`` is a function object that satisfies the requirements defined by the `C++ Standard`_
 for the equivalent parameter of `std::sort`.
@@ -723,7 +724,8 @@ and simultaneously permutes associated values at the same positions in the range
 ``[values_first, values_first + std::distance(keys_first, keys_last))``
 to match the order of the sorted keys.
 
-The order of equal keys is preserved.
+Sorting is stable. That means, keys that do not precede one another according to the given comparator
+and their associated values maintain their relative order as in the original sequences.
 
 `comp`` is a function object that satisfies the requirements defined by the `C++ Standard`_
 for the equivalent parameter of `std::sort`.

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -688,5 +688,39 @@ than an element in the range being searched.
 
 The elements e of [start, end) must be partitioned with respect to the comparator used.
 
+.. code:: cpp
+
+    template<typename Policy, typename InputKeyIt, typename InputValueIt,
+        typename Comparator =
+            std::less<typename std::iterator_traits<InputIt>::value_type>>
+    void
+    sort_by_key(Policy&& policy, InputKeyIt keys_first, InputKeyIt keys_last,
+                InputValueIt values_first, Comparator comp =
+                    std::less<typename std::iterator_traits<InputKeyIt>::value_type>());
+
+:code:`oneapi::dpl::sort_by_key` sorts a sequence of keys in the range :code:`[keys_first, keys_last)`
+and permutes a sequnce of values in the range
+:code:`[values_first, values_first + distance(keys_first, keys_last))` according to the sorted order of the keys.
+The order of equal keys is not guaranteed to be preserved.
+
+If no comparator is provided, the keys are sorted with respect to :code:`std::less`.
+
+.. code:: cpp
+
+    template<typename Policy, typename InputKeyIt, typename InputValueIt,
+      typename Comparator =
+          std::less<typename std::iterator_traits<InputIt>::value_type>>
+    void
+    stable_sort_by_key(Policy&& policy, InputKeyIt keys_first, InputKeyIt keys_last,
+                InputValueIt values_first, Comparator comp =
+                    std::less<typename std::iterator_traits<InputKeyIt>::value_type>());
+
+:code:`oneapi::dpl::stable_sort_by_key` sorts a sequence of keys in the range :code:`[keys_first, keys_last)`
+and permutes a sequnce of values in the range
+:code:`[values_first, values_first + distance(keys_first, keys_last))` according to the sorted order of the keys.
+The order of equal keys is guaranteed to be preserved.
+
+If no comparator is provided, the keys are sorted with respect to :code:`std::less`.
+
 .. _`C++ Standard`: https://isocpp.org/std/the-standard
 .. _`SYCL`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -706,7 +706,7 @@ Sorting is unstable. That means, keys that do not precede one another according 
 and their associated values might be ordered arbitrarily relative to each other.
 
 ``comp`` is a function object that satisfies the requirements defined by the `C++ Standard`_
-for the equivalent parameter of ``std::sort``.
+for the ``Compare`` parameter of ``std::sort``.
 If no ``comp`` object is provided, the keys are sorted with respect to ``std::less``.
 
 .. code:: cpp
@@ -727,7 +727,7 @@ Sorting is stable. That means, keys that do not precede one another according to
 and their associated values maintain their relative order as in the original sequences.
 
 ``comp`` is a function object that satisfies the requirements defined by the `C++ Standard`_
-for the equivalent parameter of ``std::sort``.
+for the ``Compare`` parameter of ``std::sort``.
 If no ``comp`` object is provided, the keys are sorted with respect to ``std::less``.
 
 .. _`C++ Standard`: https://isocpp.org/std/the-standard


### PR DESCRIPTION
Proposing `oneapi::dpl::sort_by_key` and `oneapi::dpl::stable_sort_by_key` specification for oneDPL.