### PR TITLE
[oneDPL] Histogram spec version 1b (draft)

### DIFF
--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -524,39 +524,29 @@ The elements of ``[start, end)`` must be partitioned with respect to the compara
         typename ValueType>
     OutputIt
     histogram(Policy&& exec, InputIt start, InputIt end, Size num_bins,
-        ValueType first_bin_min_val, ValueType last_bin_max_val, OutputIt histogram_first)
-
-:code:`oneapi::dpl::histogram` performs a histogram operation over the data in :code:`[start, end)`
-into :code:`num_bins` bins stored in a sequence which starts with :code:`histogram_first`. The
-elements of :code:`[start, end)` are mapped into evenly divided bins between :code:`first_bin_min_val`
-and :code:`last_bin_max_val` such that an input element :code:`*(start + i)` maps to a bin index
-:code:`j` such that
-:code:`j = floor((*(start + i) - first_bin_min_val) / ((last_bin_max_val - first_bin_min_val) / num_bins)))`.
-The histogram operation counts the number of elements mapped to each bin and stores the count into
-:code:`*(histogram_first + j)` within the sequence :code:`[histogram_first, histogram_first + num_bins)`.
-Input values which do not map to a defined bin are skipped silently. Sufficient output data to store each
-bin must be provided, and :code:`Size` must be sufficient to store the counts of the histogram without overflow.
-All input and output sequences must be ``RandomAccessIterators``.
-
-
-.. code:: cpp
+        ValueType first_bin_min_val, ValueType last_bin_max_val, OutputIt histogram_first) // (1)
 
     template <typename Policy, typename InputIt1, typename InputIt2, typename OutputIt>
     OutputIt
     histogram(Policy&& exec, InputIt1 start, InputIt1 end, InputIt2 boundary_start,
-              InputIt2 boundary_end, OutputIt histogram_first)
+              InputIt2 boundary_end, OutputIt histogram_first)                             // (2)
 
-:code:`oneapi::dpl::histogram` performs a histogram operation over the data in :code:`[start, end)`
-into :code:`num_bins` bins stored in a sequence which starts with :code:`histogram_first`. The
-elements of :code:`[start, end)` are  mapped into bins as defined by their boundaries in
-:code:`[boundary_start, boundary_end)` such that an input element :code:`*(start + i)` maps to a bin
-index :code:`j` if and only if
-:code:`(boundary_start[j] <= *(start + i)) && (*(start + i) < boundary_start[j + 1])`.
-The histogram operation counts the number of elements mapped to each bin and stores the count into
-:code:`*(histogram_first + j)` within the sequence :code:`[histogram_first, histogram_first + num_bins)`.
-Input values which do not map to a defined bin are skipped silently. Sufficient output data to store each
-bin must be provided, and :code:`Size` must be sufficient to store the counts of the histogram without overflow.
+:code:`oneapi::dpl::histogram` performs a histogram operation over the data in :code:`[start, end)`,
+which counts the number of elements which map to a each of a set of bins and stores the count into
+a sequence in :code:`[histogram_first, histogram_first + num_bins)`. Input values which do not map
+to a defined bin are skipped silently. Sufficient output data to store each bin must be provided,
+and :code:`Size` must be sufficient to store the counts of the histogram without overflow.
 All input and output sequences must be ``RandomAccessIterators``.
+
+(1) The elements of :code:`[start, end)` are mapped into evenly divided bins between
+:code:`first_bin_min_val` and :code:`last_bin_max_val` such that an input element :code:`start[i]`
+maps into a bin :code:`histogram_first[j]` where
+:code:`j = floor((start[i] - first_bin_min_val) / ((last_bin_max_val - first_bin_min_val) / num_bins)))`.
+
+(2) The elements of :code:`[start, end)` are mapped into bins as defined by bin boundaries in
+:code:`[boundary_start, boundary_end)` such that an input element :code:`start[i]` maps to a bin
+:code:`histogram_first[j]` if and only if
+:code:`(boundary_start[j] <= start[i]) && (start[i] < boundary_start[j + 1])`.
 
 .. _`C++ Standard`: https://isocpp.org/std/the-standard
 .. _`SYCL`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -537,7 +537,6 @@ by counting the number of elements that map to each of a set of bins and storing
 :code:`[histogram_first, histogram_first + num_bins)`. Input values that do not map
 to a defined bin are skipped silently. Sufficient output data to store each count must be provided,
 and :code:`Size` must be sufficient to store the counts of the histogram without overflow.
-All input and output sequences must be ``RandomAccessIterators``.
 
 1. The elements of :code:`[start, end)` are mapped into evenly divided bins between
 :code:`first_bin_min_val` and :code:`last_bin_max_val` such that an input element :code:`start[i]`

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -536,7 +536,8 @@ The elements of ``[start, end)`` must be partitioned with respect to the compara
 by counting the number of elements that map to each of a set of bins and storing the counts into
 the output sequence starting from :code:`histogram_first`. Input values that do not map to a defined
 bin are skipped silently. The value type of :code:`OutputIt` must be an integral type of sufficient
-size to store the counts of the histogram without overflow.
+size to store the counts of the histogram without overflow. The return value is an iterator targeting
+past the last element of the output sequence starting from :code:`histogram_first`.
 
 1. The elements of :code:`[start, end)` are mapped into :code:`num_intervals` bins that evenly divide the range
    :code:`[first_interval_begin, last_interval_end)`. Each bin is of size

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -524,7 +524,7 @@ The elements of ``[start, end)`` must be partitioned with respect to the compara
     template <typename Policy, typename InputIt, typename Size, typename OutputIt,
         typename ValueType>
     OutputIt
-    histogram(Policy&& exec, InputIt start, InputIt end, Size num_bins,
+    histogram(Policy&& exec, InputIt start, InputIt end, Size num_intervals,
         ValueType first_interval_begin, ValueType last_interval_end, OutputIt histogram_first); // (1)
 
     template <typename Policy, typename InputIt1, typename InputIt2, typename OutputIt>
@@ -534,13 +534,13 @@ The elements of ``[start, end)`` must be partitioned with respect to the compara
 
 :code:`oneapi::dpl::histogram` computes the histogram over the data in :code:`[start, end)`
 by counting the number of elements that map to each of a set of bins and storing the counts into
-:code:`[histogram_first, histogram_first + num_bins)`. Input values that do not map to a defined
+:code:`[histogram_first, histogram_first + num_intervals)`. Input values that do not map to a defined
 bin are skipped silently. The value type of :code:`OutputIt` must be an integral type of sufficient
 size to store the counts of the histogram without overflow.
 
-1. The elements of :code:`[start, end)` are mapped into :code:`num_bins` bins that evenly divide the range
+1. The elements of :code:`[start, end)` are mapped into :code:`num_intervals` bins that evenly divide the range
    :code:`[first_interval_begin, last_interval_end)`. Each bin is of size
-   :code:`bin_size = (last_interval_end - first_interval_begin) / num_bins` as represented by a real
+   :code:`bin_size = (last_interval_end - first_interval_begin) / num_intervals` as represented by a real
    number without rounding or truncation. An input element maps to a bin :code:`histogram_first[j]`
    if and only if
    :code:`(first_interval_begin + j * bin_size <= start[i]) && (start[i] < first_interval_begin + (j + 1) * bin_size)`.

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -541,16 +541,16 @@ size to store the counts of the histogram without overflow.
 1. The elements of :code:`[start, end)` are mapped into :code:`num_intervals` bins that evenly divide the range
    :code:`[first_interval_begin, last_interval_end)`. Each bin is of size
    :code:`bin_size = (last_interval_end - first_interval_begin) / num_intervals` as represented by a real
-   number without rounding or truncation. An input element maps to a bin :code:`histogram_first[j]`
-   if and only if
+   number without rounding or truncation. An input element :code:`start[i]` maps to a bin
+   :code:`histogram_first[j]` if and only if
    :code:`(first_interval_begin + j * bin_size <= start[i]) && (start[i] < first_interval_begin + (j + 1) * bin_size)`.
    `ValueType` must be an arithmetic type. The value type of :code:`InputIt` must be an arithmetic type.
 
 2. The elements of :code:`[start, end)` are mapped into :code:`(boundary_end - boundary_start - 1)`
-   bins as defined by bin boundaries in :code:`[boundary_start, boundary_end)` such that an input 
+   bins defined by the values in :code:`[boundary_start, boundary_end)`. An input 
    element :code:`start[i]` maps to a bin :code:`histogram_first[j]` if and only if
    :code:`(boundary_start[j] <= start[i]) && (start[i] < boundary_start[j + 1])`.  The value types
-   of :code:`InputIt1` and :code:`InputIt2` must be arithmetic types. The elements of 
+   of :code:`InputIt1` and :code:`InputIt2` must be arithmetic types. The values in
    :code:`[boundary_start, boundary_end)` must be sorted with respect to :code:`operator<`.
 
 .. _`C++ Standard`: https://isocpp.org/std/the-standard

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -535,7 +535,7 @@ The elements of ``[start, end)`` must be partitioned with respect to the compara
 :code:`oneapi::dpl::histogram` performs a histogram operation over the data in :code:`[start, end)`,
 which counts the number of elements which map to a each of a set of bins and stores the count into
 a sequence in :code:`[histogram_first, histogram_first + num_bins)`. Input values which do not map
-to a defined bin are skipped silently. Sufficient output data to store each bin must be provided,
+to a defined bin are skipped silently. Sufficient output data to store each count must be provided,
 and :code:`Size` must be sufficient to store the counts of the histogram without overflow.
 All input and output sequences must be ``RandomAccessIterators``.
 

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -520,6 +520,7 @@ than an element in the range being searched.
 The elements of ``[start, end)`` must be partitioned with respect to the comparator used.
 
 .. code:: cpp
+
     template <typename Policy, typename InputIt, typename Size, typename OutputIt,
         typename ValueType>
     OutputIt

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -532,27 +532,27 @@ The elements of ``[start, end)`` must be partitioned with respect to the compara
     histogram(Policy&& exec, InputIt1 start, InputIt1 end, InputIt2 boundary_start,
               InputIt2 boundary_end, OutputIt histogram_first);                             // (2)
 
-:code:`oneapi::dpl::histogram` computes the histogram over the data in :code:`[start, end)`
+``oneapi::dpl::histogram`` computes the histogram over the data in ``[start, end)``
 by counting the number of elements that map to each of a set of bins and storing the counts into
-the output sequence starting from :code:`histogram_first`. Input values that do not map to a defined
-bin are skipped silently. The value type of :code:`OutputIt` must be an integral type of sufficient
+the output sequence starting from ``histogram_first``. Input values that do not map to a defined
+bin are skipped silently. The value type of ``OutputIt`` must be an integral type of sufficient
 size to store the counts of the histogram without overflow. The return value is an iterator targeting
-past the last element of the output sequence starting from :code:`histogram_first`.
+past the last element of the output sequence starting from ``histogram_first``.
 
-1. The elements of :code:`[start, end)` are mapped into :code:`num_intervals` bins that evenly divide the range
-   :code:`[first_interval_begin, last_interval_end)`. Each bin is of size
-   :code:`bin_size = (last_interval_end - first_interval_begin) / num_intervals` as represented by a real
-   number without rounding or truncation. An input element :code:`start[i]` maps to a bin
-   :code:`histogram_first[j]` if and only if
-   :code:`(first_interval_begin + j * bin_size <= start[i]) && (start[i] < first_interval_begin + (j + 1) * bin_size)`.
-   `ValueType` must be an arithmetic type. The value type of :code:`InputIt` must be an arithmetic type.
+1. The elements of ``[start, end)`` are mapped into ``num_intervals`` bins that evenly divide the range
+   ``[first_interval_begin, last_interval_end)``. Each bin is of size
+   ``bin_size = (last_interval_end - first_interval_begin) / num_intervals`` as represented by a real
+   number without rounding or truncation. An input element ``start[i]`` maps to a bin
+   ``histogram_first[j]`` if and only if
+   ``(first_interval_begin + j * bin_size <= start[i]) && (start[i] < first_interval_begin + (j + 1) * bin_size)``.
+   `ValueType` must be an arithmetic type. The value type of ``InputIt`` must be an arithmetic type.
 
-2. The elements of :code:`[start, end)` are mapped into :code:`(boundary_end - boundary_start - 1)`
-   bins defined by the values in :code:`[boundary_start, boundary_end)`. An input 
-   element :code:`start[i]` maps to a bin :code:`histogram_first[j]` if and only if
-   :code:`(boundary_start[j] <= start[i]) && (start[i] < boundary_start[j + 1])`.  The value types
-   of :code:`InputIt1` and :code:`InputIt2` must be arithmetic types. The values in
-   :code:`[boundary_start, boundary_end)` must be sorted with respect to :code:`operator<`.
+2. The elements of ``[start, end)`` are mapped into ``(boundary_end - boundary_start - 1)``
+   bins defined by the values in ``[boundary_start, boundary_end)``. An input 
+   element ``start[i]`` maps to a bin ``histogram_first[j]`` if and only if
+   ``(boundary_start[j] <= start[i]) && (start[i] < boundary_start[j + 1])``.  The value types
+   of ``InputIt1`` and ``InputIt2`` must be arithmetic types. The values in
+   ``[boundary_start, boundary_end)`` must be sorted with respect to ``operator<``.
 
 .. _`C++ Standard`: https://isocpp.org/std/the-standard
 .. _`SYCL`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -538,12 +538,12 @@ to a defined bin are skipped silently. Sufficient output data to store each bin 
 and :code:`Size` must be sufficient to store the counts of the histogram without overflow.
 All input and output sequences must be ``RandomAccessIterators``.
 
-(1) The elements of :code:`[start, end)` are mapped into evenly divided bins between
+1. The elements of :code:`[start, end)` are mapped into evenly divided bins between
 :code:`first_bin_min_val` and :code:`last_bin_max_val` such that an input element :code:`start[i]`
 maps into a bin :code:`histogram_first[j]` where
 :code:`j = floor((start[i] - first_bin_min_val) / ((last_bin_max_val - first_bin_min_val) / num_bins)))`.
 
-(2) The elements of :code:`[start, end)` are mapped into bins as defined by bin boundaries in
+2. The elements of :code:`[start, end)` are mapped into bins as defined by bin boundaries in
 :code:`[boundary_start, boundary_end)` such that an input element :code:`start[i]` maps to a bin
 :code:`histogram_first[j]` if and only if
 :code:`(boundary_start[j] <= start[i]) && (start[i] < boundary_start[j + 1])`.

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -525,12 +525,12 @@ The elements of ``[start, end)`` must be partitioned with respect to the compara
         typename ValueType>
     OutputIt
     histogram(Policy&& exec, InputIt start, InputIt end, Size num_bins,
-        ValueType first_bin_min_val, ValueType last_bin_max_val, OutputIt histogram_first) // (1)
+        ValueType first_bin_min_val, ValueType last_bin_max_val, OutputIt histogram_first); // (1)
 
     template <typename Policy, typename InputIt1, typename InputIt2, typename OutputIt>
     OutputIt
     histogram(Policy&& exec, InputIt1 start, InputIt1 end, InputIt2 boundary_start,
-              InputIt2 boundary_end, OutputIt histogram_first)                             // (2)
+              InputIt2 boundary_end, OutputIt histogram_first);                             // (2)
 
 :code:`oneapi::dpl::histogram` performs a histogram operation over the data in :code:`[start, end)`,
 which counts the number of elements which map to a each of a set of bins and stores the count into

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -550,4 +550,3 @@ maps into a bin :code:`histogram_first[j]` where
 
 .. _`C++ Standard`: https://isocpp.org/std/the-standard
 .. _`SYCL`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html
- 

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -532,9 +532,9 @@ The elements of ``[start, end)`` must be partitioned with respect to the compara
     histogram(Policy&& exec, InputIt1 start, InputIt1 end, InputIt2 boundary_start,
               InputIt2 boundary_end, OutputIt histogram_first);                             // (2)
 
-:code:`oneapi::dpl::histogram` performs a histogram operation over the data in :code:`[start, end)`,
-which counts the number of elements that map to each of a set of bins and stores the count into
-a sequence in :code:`[histogram_first, histogram_first + num_bins)`. Input values that do not map
+:code:`oneapi::dpl::histogram` computes the histogram over the data in :code:`[start, end)`
+by counting the number of elements that map to each of a set of bins and storing the counts into
+:code:`[histogram_first, histogram_first + num_bins)`. Input values that do not map
 to a defined bin are skipped silently. Sufficient output data to store each count must be provided,
 and :code:`Size` must be sufficient to store the counts of the histogram without overflow.
 All input and output sequences must be ``RandomAccessIterators``.

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -525,7 +525,7 @@ The elements of ``[start, end)`` must be partitioned with respect to the compara
         typename ValueType>
     OutputIt
     histogram(Policy&& exec, InputIt start, InputIt end, Size num_bins,
-        ValueType first_bin_min_val, ValueType last_bin_max_val, OutputIt histogram_first); // (1)
+        ValueType first_interval_begin, ValueType last_interval_end, OutputIt histogram_first); // (1)
 
     template <typename Policy, typename InputIt1, typename InputIt2, typename OutputIt>
     OutputIt
@@ -540,11 +540,11 @@ value type of :code:`OutputIt` must be an integral type sufficient to store the 
 histogram without overflow.
 
 1. The elements of :code:`[start, end)` are mapped into bins which are evenly divided between
-:code:`first_bin_min_val` and :code:`last_bin_max_val`. Each bin is of size
-:code:`bin_size = (last_bin_max_val - first_bin_min_val) / num_bins` as represented by a real
+:code:`first_interval_begin` and :code:`last_interval_end`. Each bin is of size
+:code:`bin_size = (last_interval_end - first_interval_begin) / num_bins` as represented by a real
 number without rounding or truncation. An input element maps to a bin :code:`histogram_first[j]`
 if and only if
-:code:`(first_bin_min_val + j * bin_size <= start[i]) && (start[i] < first_bin_min_val + (j + 1) * bin_size)`.
+:code:`(first_interval_begin + j * bin_size <= start[i]) && (start[i] < first_interval_begin + (j + 1) * bin_size)`.
 `ValueType` must be an arithmetic type. The value type of :code:`InputIt` must be an arithmetic type.
 
 2. The elements of :code:`[start, end)` are mapped into bins as defined by bin boundaries in
@@ -552,7 +552,7 @@ if and only if
 :code:`histogram_first[j]` if and only if
 :code:`(boundary_start[j] <= start[i]) && (start[i] < boundary_start[j + 1])`.  The value types
 of :code:`InputIt1` and :code:`InputIt2` must be arithmetic types. The elements of 
-:code:`[boundary_start,boundary_end)` must be sorted with respect to :code:`operator<`.
+:code:`[boundary_start, boundary_end)` must be sorted with respect to :code:`operator<`.
 
 .. _`C++ Standard`: https://isocpp.org/std/the-standard
 .. _`SYCL`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -538,17 +538,17 @@ by counting the number of elements that map to each of a set of bins and storing
 bin are skipped silently. The value type of :code:`OutputIt` must be an integral type of sufficient
 size to store the counts of the histogram without overflow.
 
-1. The elements of :code:`[start, end)` are mapped into bins which are evenly divided between
-   :code:`first_interval_begin` and :code:`last_interval_end`. Each bin is of size
+1. The elements of :code:`[start, end)` are mapped into :code:`num_bins` bins that evenly divide the range
+   :code:`[first_interval_begin, last_interval_end)`. Each bin is of size
    :code:`bin_size = (last_interval_end - first_interval_begin) / num_bins` as represented by a real
    number without rounding or truncation. An input element maps to a bin :code:`histogram_first[j]`
    if and only if
    :code:`(first_interval_begin + j * bin_size <= start[i]) && (start[i] < first_interval_begin + (j + 1) * bin_size)`.
    `ValueType` must be an arithmetic type. The value type of :code:`InputIt` must be an arithmetic type.
 
-2. The elements of :code:`[start, end)` are mapped into bins as defined by bin boundaries in
-   :code:`[boundary_start, boundary_end)` such that an input element :code:`start[i]` maps to a bin
-   :code:`histogram_first[j]` if and only if
+2. The elements of :code:`[start, end)` are mapped into :code:`(boundary_end - boundary_start - 1)`
+   bins as defined by bin boundaries in :code:`[boundary_start, boundary_end)` such that an input 
+   element :code:`start[i]` maps to a bin :code:`histogram_first[j]` if and only if
    :code:`(boundary_start[j] <= start[i]) && (start[i] < boundary_start[j + 1])`.  The value types
    of :code:`InputIt1` and :code:`InputIt2` must be arithmetic types. The elements of 
    :code:`[boundary_start, boundary_end)` must be sorted with respect to :code:`operator<`.

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -540,19 +540,19 @@ value type of :code:`OutputIt` must be an integral type sufficient to store the 
 histogram without overflow.
 
 1. The elements of :code:`[start, end)` are mapped into bins which are evenly divided between
-:code:`first_interval_begin` and :code:`last_interval_end`. Each bin is of size
-:code:`bin_size = (last_interval_end - first_interval_begin) / num_bins` as represented by a real
-number without rounding or truncation. An input element maps to a bin :code:`histogram_first[j]`
-if and only if
-:code:`(first_interval_begin + j * bin_size <= start[i]) && (start[i] < first_interval_begin + (j + 1) * bin_size)`.
-`ValueType` must be an arithmetic type. The value type of :code:`InputIt` must be an arithmetic type.
+   :code:`first_interval_begin` and :code:`last_interval_end`. Each bin is of size
+   :code:`bin_size = (last_interval_end - first_interval_begin) / num_bins` as represented by a real
+   number without rounding or truncation. An input element maps to a bin :code:`histogram_first[j]`
+   if and only if
+   :code:`(first_interval_begin + j * bin_size <= start[i]) && (start[i] < first_interval_begin + (j + 1) * bin_size)`.
+   `ValueType` must be an arithmetic type. The value type of :code:`InputIt` must be an arithmetic type.
 
 2. The elements of :code:`[start, end)` are mapped into bins as defined by bin boundaries in
-:code:`[boundary_start, boundary_end)` such that an input element :code:`start[i]` maps to a bin
-:code:`histogram_first[j]` if and only if
-:code:`(boundary_start[j] <= start[i]) && (start[i] < boundary_start[j + 1])`.  The value types
-of :code:`InputIt1` and :code:`InputIt2` must be arithmetic types. The elements of 
-:code:`[boundary_start, boundary_end)` must be sorted with respect to :code:`operator<`.
+   :code:`[boundary_start, boundary_end)` such that an input element :code:`start[i]` maps to a bin
+   :code:`histogram_first[j]` if and only if
+   :code:`(boundary_start[j] <= start[i]) && (start[i] < boundary_start[j + 1])`.  The value types
+   of :code:`InputIt1` and :code:`InputIt2` must be arithmetic types. The elements of 
+   :code:`[boundary_start, boundary_end)` must be sorted with respect to :code:`operator<`.
 
 .. _`C++ Standard`: https://isocpp.org/std/the-standard
 .. _`SYCL`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -526,15 +526,16 @@ The elements of ``[start, end)`` must be partitioned with respect to the compara
     histogram(Policy&& exec, InputIt start, InputIt end, Size num_bins,
         ValueType first_bin_min_val, ValueType last_bin_max_val, OutputIt histogram_first)
 
-:code:`oneapi::dpl::histogram` performs a histogram operation over the data in :code:`[start, end]`
+:code:`oneapi::dpl::histogram` performs a histogram operation over the data in :code:`[start, end)`
 into :code:`num_bins` bins stored in a sequence which starts with :code:`histogram_first`. The
-input sequence is mapped into evenly divided bins between :code:`first_bin_min_val` and 
-:code:`last_bin_max_val` such that an input element ``a`` maps to a bin index ``i`` such that
-``i = floor((a - first_bin_min_val) / ((last_bin_max_val - first_bin_min_val) / num_bins)))``.
-The histogram operation counts the number of elements mapped to each bin and stores the count in
-the sequnce which starts with :code:`histogram_first`. Input values which do not map to a defined
-bin are skipped silently. The user must provide sufficient output data to store each bin, and the
-type of the output sequence must be sufficient to store the counts of the histogram without overflow.
+elements of :code:`[start, end)` are mapped into evenly divided bins between :code:`first_bin_min_val`
+and :code:`last_bin_max_val` such that an input element :code:`*(start + i)` maps to a bin index
+:code:`j` such that
+:code:`j = floor((*(start + i) - first_bin_min_val) / ((last_bin_max_val - first_bin_min_val) / num_bins)))`.
+The histogram operation counts the number of elements mapped to each bin and stores the count into
+:code:`*(histogram_first + j)` within the sequence :code:`[histogram_first, histogram_first + num_bins)`.
+Input values which do not map to a defined bin are skipped silently. Sufficient output data to store each
+bin must be provided, and :code:`Size` must be sufficient to store the counts of the histogram without overflow.
 All input and output sequences must be ``RandomAccessIterators``.
 
 
@@ -545,15 +546,16 @@ All input and output sequences must be ``RandomAccessIterators``.
     histogram(Policy&& exec, InputIt1 start, InputIt1 end, InputIt2 boundary_start,
               InputIt2 boundary_end, OutputIt histogram_first)
 
-:code:`oneapi::dpl::histogram` performs a histogram operation over the data in :code:`[start, end]`
+:code:`oneapi::dpl::histogram` performs a histogram operation over the data in :code:`[start, end)`
 into :code:`num_bins` bins stored in a sequence which starts with :code:`histogram_first`. The
-input sequence is mapped into bins as defined by their boundaries in
-:code:`[boundary_start, boundary_end]` such that an input element ``a`` maps to a bin index ``i``
-if and only if ``boundary_start[i] <= a < boundary_start[i + 1]``.
-The histogram operation counts the number of elements mapped to each bin and stores the count in
-the sequnce which starts with :code:`histogram_first`. Input values which do not map to a defined
-bin are skipped silently. The user must provide sufficient output data to store each bin, and the
-type of the output sequence must be sufficient to store the counts of the histogram without overflow.
+elements of :code:`[start, end)` are  mapped into bins as defined by their boundaries in
+:code:`[boundary_start, boundary_end)` such that an input element :code:`*(start + i)` maps to a bin
+index :code:`j` if and only if
+:code:`(boundary_start[j] <= *(start + i)) && (*(start + i) < boundary_start[j + 1])`.
+The histogram operation counts the number of elements mapped to each bin and stores the count into
+:code:`*(histogram_first + j)` within the sequence :code:`[histogram_first, histogram_first + num_bins)`.
+Input values which do not map to a defined bin are skipped silently. Sufficient output data to store each
+bin must be provided, and :code:`Size` must be sufficient to store the counts of the histogram without overflow.
 All input and output sequences must be ``RandomAccessIterators``.
 
 .. _`C++ Standard`: https://isocpp.org/std/the-standard

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -536,7 +536,8 @@ The elements of ``[start, end)`` must be partitioned with respect to the compara
 by counting the number of elements that map to each of a set of bins and storing the counts into
 :code:`[histogram_first, histogram_first + num_bins)`. Input values that do not map
 to a defined bin are skipped silently. Sufficient output data to store each count must be provided,
-and :code:`Size` must be sufficient to store the counts of the histogram without overflow.
+and the value type of :code:`OutputIt` must be sufficient to store the counts of the histogram
+without overflow.
 
 1. The elements of :code:`[start, end)` are mapped into evenly divided bins between
 :code:`first_bin_min_val` and :code:`last_bin_max_val` such that an input element :code:`start[i]`

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -534,7 +534,7 @@ The elements of ``[start, end)`` must be partitioned with respect to the compara
 
 :code:`oneapi::dpl::histogram` computes the histogram over the data in :code:`[start, end)`
 by counting the number of elements that map to each of a set of bins and storing the counts into
-:code:`[histogram_first, histogram_first + num_intervals)`. Input values that do not map to a defined
+the output sequence starting from :code:`histogram_first`. Input values that do not map to a defined
 bin are skipped silently. The value type of :code:`OutputIt` must be an integral type of sufficient
 size to store the counts of the histogram without overflow.
 

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -519,5 +519,43 @@ than an element in the range being searched.
 
 The elements of ``[start, end)`` must be partitioned with respect to the comparator used.
 
+.. code:: cpp
+    template <typename Policy, typename InputIt, typename Size, typename OutputIt,
+        typename ValueType>
+    OutputIt
+    histogram(Policy&& exec, InputIt start, InputIt end, Size num_bins,
+        ValueType first_bin_min_val, ValueType last_bin_max_val, OutputIt histogram_first)
+
+:code:`oneapi::dpl::histogram` performs a histogram operation over the data in :code:`[start, end]`
+into :code:`num_bins` bins stored in a sequence which starts with :code:`histogram_first`. The
+input sequence is mapped into evenly divided bins between :code:`first_bin_min_val` and 
+:code:`last_bin_max_val` such that an input element ``a`` maps to a bin index ``i`` such that
+``i = floor((a - first_bin_min_val) / ((last_bin_max_val - first_bin_min_val) / num_bins)))``.
+The histogram operation counts the number of elements mapped to each bin and stores the count in
+the sequnce which starts with :code:`histogram_first`. Input values which do not map to a defined
+bin are skipped silently. The user must provide sufficient output data to store each bin, and the
+type of the output sequence must be sufficient to store the counts of the histogram without overflow.
+All input and output sequences must be ``RandomAccessIterators``.
+
+
+.. code:: cpp
+
+    template <typename Policy, typename InputIt1, typename InputIt2, typename OutputIt>
+    OutputIt
+    histogram(Policy&& exec, InputIt1 start, InputIt1 end, InputIt2 boundary_start,
+              InputIt2 boundary_end, OutputIt histogram_first)
+
+:code:`oneapi::dpl::histogram` performs a histogram operation over the data in :code:`[start, end]`
+into :code:`num_bins` bins stored in a sequence which starts with :code:`histogram_first`. The
+input sequence is mapped into bins as defined by their boundaries in
+:code:`[boundary_start, boundary_end]` such that an input element ``a`` maps to a bin index ``i``
+if and only if ``boundary_start[i] <= a < boundary_start[i + 1]``.
+The histogram operation counts the number of elements mapped to each bin and stores the count in
+the sequnce which starts with :code:`histogram_first`. Input values which do not map to a defined
+bin are skipped silently. The user must provide sufficient output data to store each bin, and the
+type of the output sequence must be sufficient to store the counts of the histogram without overflow.
+All input and output sequences must be ``RandomAccessIterators``.
+
 .. _`C++ Standard`: https://isocpp.org/std/the-standard
 .. _`SYCL`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html
+ 

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -533,8 +533,8 @@ The elements of ``[start, end)`` must be partitioned with respect to the compara
               InputIt2 boundary_end, OutputIt histogram_first);                             // (2)
 
 :code:`oneapi::dpl::histogram` performs a histogram operation over the data in :code:`[start, end)`,
-which counts the number of elements which map to a each of a set of bins and stores the count into
-a sequence in :code:`[histogram_first, histogram_first + num_bins)`. Input values which do not map
+which counts the number of elements that map to each of a set of bins and stores the count into
+a sequence in :code:`[histogram_first, histogram_first + num_bins)`. Input values that do not map
 to a defined bin are skipped silently. Sufficient output data to store each count must be provided,
 and :code:`Size` must be sufficient to store the counts of the histogram without overflow.
 All input and output sequences must be ``RandomAccessIterators``.

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -530,7 +530,7 @@ The elements of ``[start, end)`` must be partitioned with respect to the compara
     template <typename Policy, typename InputIt1, typename InputIt2, typename OutputIt>
     OutputIt
     histogram(Policy&& exec, InputIt1 start, InputIt1 end, InputIt2 boundary_start,
-              InputIt2 boundary_end, OutputIt histogram_first);                             // (2)
+              InputIt2 boundary_end, OutputIt histogram_first);                                 // (2)
 
 ``oneapi::dpl::histogram`` computes the histogram over the data in ``[start, end)``
 by counting the number of elements that map to each of a set of bins and storing the counts into

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -544,13 +544,13 @@ histogram without overflow.
 :code:`bin_size = (last_bin_max_val - first_bin_min_val) / num_bins` as represented by a real
 number without rounding or truncation. An input element maps to a bin :code:`histogram_first[j]`
 if and only if
-:code:`!(start[i] < first_bin_min_val + j * bin_size) && (start[i] < first_bin_min_val + (j + 1) * bin_size)`.
+:code:`(first_bin_min_val + j * bin_size <= start[i]) && (start[i] < first_bin_min_val + (j + 1) * bin_size)`.
 `ValueType` must be an arithmetic type. The value type of :code:`InputIt` must be an arithmetic type.
 
 2. The elements of :code:`[start, end)` are mapped into bins as defined by bin boundaries in
 :code:`[boundary_start, boundary_end)` such that an input element :code:`start[i]` maps to a bin
 :code:`histogram_first[j]` if and only if
-:code:`!(start[i] < boundary_start[j]) && (start[i] < boundary_start[j + 1])`.  The value types
+:code:`(boundary_start[j] <= start[i]) && (start[i] < boundary_start[j + 1])`.  The value types
 of :code:`InputIt1` and :code:`InputIt2` must be arithmetic types. The elements of 
 :code:`[boundary_start,boundary_end)` must be sorted with respect to :code:`operator<`.
 

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -535,9 +535,8 @@ The elements of ``[start, end)`` must be partitioned with respect to the compara
 :code:`oneapi::dpl::histogram` computes the histogram over the data in :code:`[start, end)`
 by counting the number of elements that map to each of a set of bins and storing the counts into
 :code:`[histogram_first, histogram_first + num_bins)`. Input values that do not map to a defined
-bin are skipped silently. Sufficient output data to store each count must be provided, and the
-value type of :code:`OutputIt` must be an integral type sufficient to store the counts of the
-histogram without overflow.
+bin are skipped silently. The value type of :code:`OutputIt` must be an integral type of sufficient
+size to store the counts of the histogram without overflow.
 
 1. The elements of :code:`[start, end)` are mapped into bins which are evenly divided between
    :code:`first_interval_begin` and :code:`last_interval_end`. Each bin is of size

--- a/source/elements/oneDPL/source/parallel_api.rst
+++ b/source/elements/oneDPL/source/parallel_api.rst
@@ -534,20 +534,25 @@ The elements of ``[start, end)`` must be partitioned with respect to the compara
 
 :code:`oneapi::dpl::histogram` computes the histogram over the data in :code:`[start, end)`
 by counting the number of elements that map to each of a set of bins and storing the counts into
-:code:`[histogram_first, histogram_first + num_bins)`. Input values that do not map
-to a defined bin are skipped silently. Sufficient output data to store each count must be provided,
-and the value type of :code:`OutputIt` must be sufficient to store the counts of the histogram
-without overflow.
+:code:`[histogram_first, histogram_first + num_bins)`. Input values that do not map to a defined
+bin are skipped silently. Sufficient output data to store each count must be provided, and the
+value type of :code:`OutputIt` must be an integral type sufficient to store the counts of the
+histogram without overflow.
 
-1. The elements of :code:`[start, end)` are mapped into evenly divided bins between
-:code:`first_bin_min_val` and :code:`last_bin_max_val` such that an input element :code:`start[i]`
-maps into a bin :code:`histogram_first[j]` where
-:code:`j = floor((start[i] - first_bin_min_val) / ((last_bin_max_val - first_bin_min_val) / num_bins)))`.
+1. The elements of :code:`[start, end)` are mapped into bins which are evenly divided between
+:code:`first_bin_min_val` and :code:`last_bin_max_val`. Each bin is of size
+:code:`bin_size = (last_bin_max_val - first_bin_min_val) / num_bins` as represented by a real
+number without rounding or truncation. An input element maps to a bin :code:`histogram_first[j]`
+if and only if
+:code:`!(start[i] < first_bin_min_val + j * bin_size) && (start[i] < first_bin_min_val + (j + 1) * bin_size)`.
+`ValueType` must be an arithmetic type. The value type of :code:`InputIt` must be an arithmetic type.
 
 2. The elements of :code:`[start, end)` are mapped into bins as defined by bin boundaries in
 :code:`[boundary_start, boundary_end)` such that an input element :code:`start[i]` maps to a bin
 :code:`histogram_first[j]` if and only if
-:code:`(boundary_start[j] <= start[i]) && (start[i] < boundary_start[j + 1])`.
+:code:`!(start[i] < boundary_start[j]) && (start[i] < boundary_start[j + 1])`.  The value types
+of :code:`InputIt1` and :code:`InputIt2` must be arithmetic types. The elements of 
+:code:`[boundary_start,boundary_end)` must be sorted with respect to :code:`operator<`.
 
 .. _`C++ Standard`: https://isocpp.org/std/the-standard
 .. _`SYCL`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html


### PR DESCRIPTION
Draft for discussion purposes.
This version uses the function signature from oneDPL existing implementation.  Alternate of #546, which contains signature which has been modified to be narrower.

Version 1b from email.