### PR TITLE
[oneDPL] Specify copy and move semantics for device_policy

### DIFF
--- a/source/elements/oneDPL/source/parallel_api/execution_policies.rst
+++ b/source/elements/oneDPL/source/parallel_api/execution_policies.rst
@@ -41,10 +41,10 @@ with the `C++ Standard`_, 6th edition (C++20):
 
 See "Execution policies" in the `C++ Standard`_ for more information.
 
-Device Execution Policy
-+++++++++++++++++++++++
+Device Execution Policies
++++++++++++++++++++++++++
 
-A device execution policy class ``oneapi::dpl::execution::device_policy`` specifies
+The device execution policy class ``oneapi::dpl::execution::device_policy`` specifies
 the `SYCL`_ device and queue to run oneDPL algorithms.
 
 .. code:: cpp
@@ -75,8 +75,6 @@ the `SYCL`_ device and queue to run oneDPL algorithms.
       }
     }
   }
-
-``dpcpp_default`` is a predefined execution policy object to run algorithms on the default SYCL device.
 
 device_policy Class
 ^^^^^^^^^^^^^^^^^^^
@@ -116,8 +114,7 @@ A policy instance constructed as or assigned a copy of another instance is assoc
 a ``sycl::queue`` that compares equal, as defined by `SYCL`_, to the queue of that other instance.
 A policy instance constructed as or assigned a move of another instance is associated with the queue
 of that other instance without copying it. It is unspecified whether the original policy is associated
-with any queue after the move. [*Note*: The predefined ``dpcpp_default`` policy object is immutable
-(``const``) and cannot be moved. -- *end note*]
+with any queue after the move.
 
 .. code:: cpp
 
@@ -156,6 +153,13 @@ Return the queue the policy is associated with.
   operator sycl::queue() const
 
 Allow implicit conversion of the policy to a ``sycl::queue`` object.
+
+Predefined Device Policy
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+``dpcpp_default`` is a predefined execution policy object to run algorithms on the default SYCL device.
+It is a global immutable (``const``) instance of type ``device_policy<>``.
+[*Note*: ``dpcpp_default`` can be copied but cannot be moved. -- *end note*]
 
 make_device_policy Function
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/elements/oneDPL/source/parallel_api/execution_policies.rst
+++ b/source/elements/oneDPL/source/parallel_api/execution_policies.rst
@@ -106,12 +106,12 @@ is a possible valid implementation.
 The ``KernelName`` template parameter, also aliased as ``kernel_name`` within the class template,
 is to explicitly provide a name for SYCL kernels executed by an algorithm the policy is passed to.
 
-The ``device_policy`` type is copy constructible, copy assignable, move constructible and move assignable.
+The ``device_policy`` type is copy-constructible, copy-assignable, move-constructible and move-assignable.
 A policy instance constructed as or assigned a copy of another instance is associated with
 a ``sycl::queue`` that compares equal, as defined by `SYCL`_, to the queue of that other instance.
 A policy instance constructed as or assigned a move of another instance is associated with the queue
-of that other instance without copying it. It is unspecified whether the original policy is associated
-with any queue after the move.
+of that other instance without copying it. It is unspecified whether the moved-from policy instance
+is associated with any queue after the move.
 
 .. code:: cpp
 

--- a/source/elements/oneDPL/source/parallel_api/execution_policies.rst
+++ b/source/elements/oneDPL/source/parallel_api/execution_policies.rst
@@ -71,11 +71,12 @@ the `SYCL`_ device and queue to run oneDPL algorithms.
         template <typename NewKernelName, typename OldKernelName>
         device_policy<NewKernelName>
         make_device_policy( const device_policy<OldKernelName>& = dpcpp_default );
+
       }
     }
   }
 
-``dpcpp_default`` is a predefined execution policy object to run algorithms on the default `SYCL`_ device.
+``dpcpp_default`` is a predefined execution policy object to run algorithms on the default SYCL device.
 
 device_policy Class
 ^^^^^^^^^^^^^^^^^^^
@@ -101,14 +102,22 @@ device_policy Class
 An object of the ``device_policy`` type is associated with a ``sycl::queue`` that is used
 to run algorithms on a SYCL device. When an algorithm runs with ``device_policy``
 it is capable of processing SYCL buffers (passed via ``oneapi::dpl::begin/end``),
-data in the host memory and data in Unified Shared Memory (USM), including USM device memory.
-Data placed in the host memory and USM can only be passed to oneDPL algorithms
+data in the host memory and data in Unified Shared Memory (USM), including device USM.
+Data placed in the host memory and USM can be passed to oneDPL algorithms
 as pointers and random access iterators. The way to transfer data from the host memory
 to a device and back is unspecified; per-element data movement to/from a temporary storage
 is a possible valid implementation.
 
 The ``KernelName`` template parameter, also aliased as ``kernel_name`` within the class template,
 is to explicitly provide a name for SYCL kernels executed by an algorithm the policy is passed to.
+
+The ``device_policy`` type is copy constructible, copy assignable, move constructible and move assignable.
+A policy instance constructed as or assigned a copy of another instance is associated with
+a ``sycl::queue`` that compares equal, as defined by `SYCL`_, to the queue of that other instance.
+A policy instance constructed as or assigned a move of another instance is associated with the queue
+of that other instance without copying it. It is unspecified whether the original policy is associated
+with any queue after the move. [*Note*: The predefined ``dpcpp_default`` policy object is immutable
+(``const``) and cannot be moved. -- *end note*]
 
 .. code:: cpp
 
@@ -121,8 +130,8 @@ Construct a policy object associated with a queue created with the default devic
   template <typename OtherName>
   device_policy( const device_policy<OtherName>& policy )
 
-Construct a policy object associated with the same queue as ``policy``, by changing
-the kernel name of the given policy to ``kernel_name`` defined for the new policy.
+Construct a policy object as if by copying ``policy`` and changing
+the kernel name to ``kernel_name`` defined for the new policy.
 
 .. code:: cpp
 

--- a/source/elements/oneDPL/source/parallel_api/execution_policies.rst
+++ b/source/elements/oneDPL/source/parallel_api/execution_policies.rst
@@ -44,8 +44,7 @@ See "Execution policies" in the `C++ Standard`_ for more information.
 Device Execution Policies
 +++++++++++++++++++++++++
 
-The device execution policy class ``oneapi::dpl::execution::device_policy`` specifies
-the `SYCL`_ device and queue to run oneDPL algorithms.
+A device execution policy represents a `SYCL`_ device and queue to run oneDPL algorithms.
 
 .. code:: cpp
 

--- a/source/elements/oneDPL/source/parallel_api/execution_policies.rst
+++ b/source/elements/oneDPL/source/parallel_api/execution_policies.rst
@@ -57,7 +57,7 @@ A device execution policy represents a `SYCL`_ device and queue to run oneDPL al
         template <typename KernelName = /*unspecified*/>
         class device_policy;
 
-        const device_policy<> dpcpp_default;
+        inline const device_policy<> dpcpp_default;
 
         template <typename KernelName = /*unspecified*/>
         device_policy<KernelName>


### PR DESCRIPTION
Addresses #271.

For this patch, I believe the 7 days review period [applies](https://github.com/uxlfoundation/uxl_operational_procedures/blob/release/Process_Documents/Organization_Operational_Process.md#review--approval-process):

> 7 days for major changes to non-API modifications (such as changes to the documentation of an API)