### PR TITLE
Extend parallel_reduce named requirements to allow rvalue reduction

### DIFF
--- a/source/elements/oneTBB/source/named_requirements/algorithms/par_reduce_func.rst
+++ b/source/elements/oneTBB/source/named_requirements/algorithms/par_reduce_func.rst
@@ -13,12 +13,18 @@ A type `Func` satisfies `ParallelReduceFunc` if it meets the following requireme
 
 **ParallelReduceFunc Requirements: Pseudo-Signature, Semantics**
 
+.. cpp:function:: Value Func::operator()(const Range& range, Value&& x) const
+
+or
+
 .. cpp:function:: Value Func::operator()(const Range& range, const Value& x) const
 
     Accumulates result for a subrange, starting with initial value ``x``.
     ``Range`` type must meet the :doc:`Range requirements <range>`.
     ``Value`` type must be the same as a corresponding template parameter for the
     :doc:`parallel_reduce algorithm <../../algorithms/functions/parallel_reduce_func>` algorithm.
+
+    If both variations are provided, the implementation should prefer the first form.
 
 See also:
 

--- a/source/elements/oneTBB/source/named_requirements/algorithms/par_reduce_reduction.rst
+++ b/source/elements/oneTBB/source/named_requirements/algorithms/par_reduce_reduction.rst
@@ -13,11 +13,17 @@ A type `Reduction` satisfies `ParallelReduceReduction` if it meets the following
 
 **ParallelReduceReduction Requirements: Pseudo-Signature, Semantics**
 
+.. cpp:function:: Value Reduction::operator()(Value&& x, Value&& y) const
+
+or
+
 .. cpp:function:: Value Reduction::operator()(const Value& x, const Value& y) const
 
     Combines results ``x`` and ``y``.
-    ``Value`` type must be the same as a corresponding template parameter for the 
+    ``Value`` type must be the same as a corresponding template parameter for the
     :doc:`parallel_reduce algorithm <../../algorithms/functions/parallel_reduce_func>` algorithm.
+
+    If both variations are provided, the implementation should prefer the first form.
 
 See also:
 


### PR DESCRIPTION
Extend `PararallelReduceFunc` and `ParallelReduceReduction` to allow user callable objects accepting rvalues.