### PR TITLE
Increase max tree depth to 4

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -16,7 +16,7 @@ for creating parallel applications:
 
 .. toctree::
    :hidden:
-   :maxdepth: 3
+   :maxdepth: 4
 
    introduction
    architecture


### PR DESCRIPTION
Fixes the other issue mentioned in https://github.com/uxlfoundation/oneAPI-spec/issues/588

https://oneapi-spec.uxlfoundation.org/specifications/oneapi/v1.4-provisional-rev-1/elements/onemkl/source/domains/spblas/data_types/data_handles# does not show the children pages under "Data handles" in the left tree. This change addresses that.

Html build: [docs.zip](https://github.com/user-attachments/files/17476880/docs.zip)
