### PR TITLE
[oneMKL][LAPACK] Fix ldc size requirements in {or,un}mtr related files

### DIFF
--- a/source/elements/oneMKL/source/domains/lapack/ormtr.rst
+++ b/source/elements/oneMKL/source/domains/lapack/ormtr.rst
@@ -54,7 +54,7 @@ In the descriptions below, ``r`` denotes the order of :math:`Q`:
 .. container:: tablenoborder
 
      .. list-table:: 
-        :header-rows: 1
+        :header-rows: 0
 
         * -  :math:`r = m` 
           -  if ``side = side::left`` 
@@ -97,7 +97,7 @@ a
    The buffer ``a`` as returned by   :ref:`onemkl_lapack_sytrd`.
 
 lda
-   The leading dimension of ``a`` :math:`(\max(1, r) \le \text{lda})`.
+   The leading dimension of ``a`` :math:`(\text{lda} \ge \max(1, r))`.
 
 tau
    The buffer ``tau`` as returned by a :ref:`onemkl_lapack_sytrd`. The
@@ -108,7 +108,7 @@ c
    must be at least :math:`\max(1, n)`.
 
 ldc
-   The leading dimension of ``c`` :math:`(\max(1, n) \le \text{ldc})`.
+   The leading dimension of ``c`` :math:`(\text{ldc} \ge \max(1, m))`.
 
 scratchpad_size
    Size of scratchpad memory as a number of floating point elements of type ``T``.
@@ -171,7 +171,7 @@ In the descriptions below, ``r`` denotes the order of :math:`Q`:
 .. container:: tablenoborder
 
      .. list-table:: 
-        :header-rows: 1
+        :header-rows: 0
 
         * -  :math:`r = m` 
           -  if ``side = side::left`` 
@@ -213,7 +213,7 @@ a
    The pointer to ``a`` as returned by   :ref:`onemkl_lapack_sytrd`.
 
 lda
-   The leading dimension of ``a`` :math:`(\max(1, r) \le \text{lda})`.
+   The leading dimension of ``a`` :math:`(\text{lda} \ge \max(1, r))`.
 
 tau
    The buffer ``tau`` as returned by   :ref:`onemkl_lapack_sytrd`. The
@@ -224,7 +224,7 @@ c
    must be at least :math:`\max(1, n)`.
 
 ldc
-   The leading dimension of ``c`` :math:`(\max(1, n) \le \text{ldc})`.
+   The leading dimension of ``c`` :math:`(\text{ldc} \ge \max(1, m))`.
 
 scratchpad_size
    Size of scratchpad memory as a number of floating point elements of type ``T``.

--- a/source/elements/oneMKL/source/domains/lapack/ormtr_scratchpad_size.rst
+++ b/source/elements/oneMKL/source/domains/lapack/ormtr_scratchpad_size.rst
@@ -48,13 +48,13 @@ In the descriptions below, ``r`` denotes the order of :math:`Q`:
 
 .. container:: tablenoborder
 
-     .. list-table:: 
-        :header-rows: 1
+     .. list-table::
+        :header-rows: 0
 
-        * -  :math:`r = m` 
-          -  if ``side = side::left`` 
-        * -  :math:`r = n` 
-          -  if ``side = side::right`` 
+        * -  :math:`r = m`
+          -  if ``side = side::left``
+        * -  :math:`r = n`
+          -  if ``side = side::right``
 
 queue
    Device queue where calculations by :ref:`onemkl_lapack_ormtr` function will be performed.
@@ -89,10 +89,10 @@ n
    The number of rows in the matrix :math:`C` :math:`(n \ge 0)`.
 
 lda
-   The leading dimension of ``a`` :math:`(\max(1, r) \le \text{lda})`.
+   The leading dimension of ``a`` :math:`(\text{lda} \ge \max(1, r))`.
 
 ldc
-   The leading dimension of ``c`` :math:`(\max(1, n) \le \text{ldc})`.
+   The leading dimension of ``c`` :math:`(\text{ldc} \ge \max(1, m))`.
 
 .. container:: section
 

--- a/source/elements/oneMKL/source/domains/lapack/unmtr.rst
+++ b/source/elements/oneMKL/source/domains/lapack/unmtr.rst
@@ -57,7 +57,7 @@ In the descriptions below, ``r`` denotes the order of :math:`Q`:
 .. container:: tablenoborder
 
      .. list-table:: 
-        :header-rows: 1
+        :header-rows: 0
 
         * -  :math:`r`\ =\ :math:`m` 
           -  if ``side = side::left`` 
@@ -106,7 +106,7 @@ a
    :ref:`onemkl_lapack_hetrd`.
 
 lda
-   The leading dimension of ``a`` :math:`(\max(1,r) \le \text{lda})`.
+   The leading dimension of ``a`` :math:`(\text{lda} \ge \max(1,r))`.
 
 tau
    The buffer ``tau`` as returned by
@@ -118,7 +118,7 @@ c
    must be at least :math:`\max(1,n)`.
 
 ldc
-   The leading dimension of ``c`` :math:`(\max(1,n) \le \text{ldc})`.
+   The leading dimension of ``c`` :math:`(\text{ldc} \ge \max(1,m))`.
 
 scratchpad_size
    Size of scratchpad memory as a number of floating point elements of type ``T``.
@@ -182,7 +182,7 @@ In the descriptions below, ``r`` denotes the order of :math:`Q`:
 .. container:: tablenoborder
 
      .. list-table:: 
-        :header-rows: 1
+        :header-rows: 0
 
         * -  :math:`r`\ =\ :math:`m` 
           -  if ``side = side::left`` 
@@ -231,7 +231,7 @@ a
    :ref:`onemkl_lapack_hetrd`.
 
 lda
-   The leading dimension of ``a`` :math:`(\max(1,r) \le \text{lda})`.
+   The leading dimension of ``a`` :math:`(\text{lda} \ge \max(1,r))`.
 
 tau
    The pointer to ``tau`` as returned by
@@ -243,7 +243,7 @@ c
    must be at least :math:`\max(1,n)`.
 
 ldc
-   The leading dimension of ``c`` :math:`(\max(1,n) \le \text{ldc})`.
+   The leading dimension of ``c`` :math:`(\text{ldc} \ge \max(1,m))`.
 
 scratchpad_size
    Size of scratchpad memory as a number of floating point elements of type ``T``.

--- a/source/elements/oneMKL/source/domains/lapack/unmtr_scratchpad_size.rst
+++ b/source/elements/oneMKL/source/domains/lapack/unmtr_scratchpad_size.rst
@@ -43,6 +43,18 @@ unmtr_scratchpad_size
 
   .. rubric:: Input Parameters
 
+In the descriptions below, ``r`` denotes the order of :math:`Q`:
+
+.. container:: tablenoborder
+
+     .. list-table::
+        :header-rows: 0
+
+        * -  :math:`r = m`
+          -  if ``side = side::left``
+        * -  :math:`r = n`
+          -  if ``side = side::right``
+
 queue
    Device queue where calculations by :ref:`onemkl_lapack_unmtr` function will be performed.
 
@@ -81,10 +93,10 @@ k
    matrix :math:`Q` (:math:`0 \le k \le n`).
 
 lda
-   The leading dimension of :math:`a` :math:`(\max(1,r) \le \text{lda})`.
+   The leading dimension of :math:`a` :math:`(\text{lda} \ge \max(1,r))`.
 
 ldc
-   The leading dimension of :math:`c` :math:`(\max(1,n) \le \text{ldc})`.
+   The leading dimension of :math:`c` :math:`(\text{ldc} \ge \max(1,m))`.
 
 .. container:: section
 


### PR DESCRIPTION
For ormtr and unmtr, the specification incorrectly specifies that LDC must be >= max(1,n), when in fact it should be >= max(1,m).
This was done for all {or,un}mtr related APIs (buffer, USM, and scratchpad size).
Also changed notation in these files to ld* >= x instead of x <= ld*.
Fixed an issue where the first row of the input parameters table had been bolded (incorrectly considered a header row) and added missing table to unmtr_scratchpad_size.