### PR TITLE
Update non-compliance version to allow definition checks

### DIFF
--- a/source/elements/oneMath/source/architecture/other_architecture.inc.rst
+++ b/source/elements/oneMath/source/architecture/other_architecture.inc.rst
@@ -26,7 +26,7 @@ The macros for each domain are listed as follows:
   | ONEMATH_STATS_SPEC_VERSION
   | ONEMATH_VM_SPEC_VERSION
 
-The specification version can be created by appending all digits of the specification version in the format of <MAJOR><MINOR>. MINOR version always uses two digits. This version can be used to check the compatibility of the implementation with the specification version. Note that the revision is not included here because it reflects changes only for the specification document without affecting the implementation. If the implementation is not compliant with any release of the specification, then the macro must have a numerical value of `000`.
+The specification version can be created by appending all digits of the specification version in the format of <MAJOR><MINOR>. MINOR version always uses two digits. This version can be used to check the compatibility of the implementation with the specification version. Note that the revision is not included here because it reflects changes only for the specification document without affecting the implementation. If the implementation is not compliant with any release of the specification, then the macro must have a numerical value of `001`. Versions between `001` and `100` are reserved for alpha/beta support of the specification in oneMKL and should only be used for special cases. A preprocessor may evaluate an undefined macro to `0`, so `000` should not be used.
 
 Version Example
 


### PR DESCRIPTION
## Problem Statement
When using a definition check,
```c
#ifdef ONEMATH_BLAS_SPEC_VERSION
```
a preprocessor may evaluate an undefined macro to `0`. This means that the existing `000` version for non-compliance is equivalent to the macro not being defined at all and yields the same result for `#ifdef`.

## Solution
To enable the check for definition of the macro itself, meaning, provide different outputs for:
```c
#define ONEMATH_BLAS_SPEC_VERSION 0   // domain non-compliant with specification
```
case and
```c
// #define ONEMATH_BLAS_SPEC_VERSION   // missing macro definition, may be 0
```
case, we need to use a number other than `0`. `001` is hence proposed as the non-compliance version. It does not conflict with any existing release of the specification. As a natural extension, versions between `001` and `100`(Spec release 1.0), can be treated as alpha/beta and used as per special cases that can be defined later as and if needed.

Thanks to @zettai-reido for detecting this issue.