### PR TITLE
Fix a bug in 'merge': execution policy parameter missed

### DIFF
--- a/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
+++ b/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
@@ -258,7 +258,8 @@ Sorting and Merge
       std::ranges::merge_result<std::ranges::borrowed_iterator_t<R1>,
                                 std::ranges::borrowed_iterator_t<R2>,
                                 std::ranges::borrowed_iterator_t<OutR>>
-        merge (R1&& r1, R2&& r2, OutR&& result, Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
+        merge (ExecutionPolicy&& pol, R1&& r1, R2&& r2, OutR&& result, Comp comp = {},
+               Proj1 proj1 = {}, Proj2 proj2 = {});
 
   }
 


### PR DESCRIPTION
It's an oversight in the algorithm signature. Ideally it should be added to a revision of the specification v1.4.