### PR TITLE
[oneMath][RNG] Updated supported types for Discrete Uniform

### DIFF
--- a/source/elements/oneMath/source/domains/rng/device_api/device-rng-uniform-discrete.rst
+++ b/source/elements/oneMath/source/domains/rng/device_api/device-rng-uniform-discrete.rst
@@ -70,6 +70,10 @@ class uniform
         typename Type
             Type of the produced values. Supported types:
 
+                * ``std::int8_t``
+                * ``std::uint8_t``
+                * ``std::int16_t``
+                * ``std::uint16_t``
                 * ``std::int32_t``
                 * ``std::uint32_t``
                 * ``std::int64_t``


### PR DESCRIPTION
Since (u)int8 and (u)int16 types support was added to Uniform at the DPNP request