### PR TITLE
[oneMath][RNG] Make number of generators for MT2203 be implementation defined

### DIFF
--- a/source/elements/oneMath/source/domains/rng/host_api/engines-basic-random-number-generators.rst
+++ b/source/elements/oneMath/source/domains/rng/host_api/engines-basic-random-number-generators.rst
@@ -40,7 +40,7 @@ Host Engines (Basic Random Number Generators)
          * -                      \ :ref:`onemath_rng_mt19937`\
            -     Mersenne Twister pseudorandom number generator       ``MT19937``\ :ref:`[Matsumoto98] <onemath_rng_bibliography>`      with period length 2\ :sup:`19937`-1 of the produced sequence
          * -                      \ :ref:`onemath_rng_mt2203`\
-           -     Set of 6024 Mersenne Twister pseudorandom number       generators      ``MT2203``\ :ref:`[Matsumoto98] <onemath_rng_bibliography>`,      :ref:`[Matsumoto00] <onemath_rng_bibliography>`.      Each of them generates a sequence of period length equal to      2\ :sup:`2203`-1. Parameters of the generators provide mutual      independence of the corresponding sequences.
+           -     Set of Mersenne Twister pseudorandom number       generators      ``MT2203``\ :ref:`[Matsumoto98] <onemath_rng_bibliography>`,      :ref:`[Matsumoto00] <onemath_rng_bibliography>`.      Each of them generates a sequence of period length equal to      2\ :sup:`2203`-1. Parameters of the generators provide mutual      independence of the corresponding sequences.
          * -                      \ :ref:`onemath_rng_sfmt19937`\
            -     SIMD-oriented Fast Mersenne Twister pseudorandom       number generator      ``SFMT19937``\ :ref:`[Saito08] <onemath_rng_bibliography>`      with a period length equal to 2\ :sup:`19937`-1 of the produced      sequence.
          * -                      \ :ref:`onemath_rng_sobol`\
@@ -62,8 +62,8 @@ Host Engines (Basic Random Number Generators)
    description of these functions can be found in the :ref:`onemath_rng_service_routines` section.
 
 
-   In addition, the MT2203 pseudorandom number generator is a set of 6024
-   generators designed to create up to 6024 independent random
+   In addition, the MT2203 pseudorandom number generator is a set of
+   generators designed to create independent random
    sequences, which might be used in parallel Monte Carlo simulations.
    Another generator that has the same feature is Wichmann-Hill. It
    allows creating up to 273 independent random streams. The properties
@@ -107,7 +107,7 @@ Host Engines (Basic Random Number Generators)
       SFMT19937 [Saito08] with a period length equal to
       2\ :sup:`19937`-1 of the produced sequence.
    -  :ref:`onemath_rng_mt2203`
-      Set of 6024 Mersenne Twister pseudorandom number generators MT2203
+      Set of Mersenne Twister pseudorandom number generators MT2203
       [Matsumoto98], [Matsumoto00]. Each of them generates a sequence of
       period length equal to 2\ :sup:`2203`-1. Parameters of the
       generators provide mutual independence of the corresponding

--- a/source/elements/oneMath/source/domains/rng/host_api/onemath-rng-mt2203.rst
+++ b/source/elements/oneMath/source/domains/rng/host_api/onemath-rng-mt2203.rst
@@ -240,4 +240,4 @@ class mt2203
 
 **Parent topic:** :ref:`onemath_rng_engines_basic_random_number_generators`
 
-.. _`the following reference`: https://www.math.sci.hiroshima-u.ac.jp/m-mat/MT/DC/dc.html
+.. _`the following tool`: https://www.math.sci.hiroshima-u.ac.jp/m-mat/MT/DC/dc.html

--- a/source/elements/oneMath/source/domains/rng/host_api/onemath-rng-mt2203.rst
+++ b/source/elements/oneMath/source/domains/rng/host_api/onemath-rng-mt2203.rst
@@ -8,7 +8,7 @@ mt2203
 ======
 
 The mt2203 engine is the set of Mersenne Twister pseudorandom number generators MT2203 [:ref:`Matsumoto98 <onemath_rng_bibliography>`], [:ref:`Matsumoto00 <onemath_rng_bibliography>`].
-Coefficients are obtained by `the following tool`_. The amount of engines in the set (denoted `n_engines`) is implementation defined.
+Coefficients are obtained by `the following tool`_. The amount of generators in the set (denoted `n_engines`) is implementation defined.
 
 .. _onemath_rng_mt2203_description:
 

--- a/source/elements/oneMath/source/domains/rng/host_api/onemath-rng-mt2203.rst
+++ b/source/elements/oneMath/source/domains/rng/host_api/onemath-rng-mt2203.rst
@@ -7,19 +7,21 @@
 mt2203
 ======
 
-The mt2203 engine is the set of 6024 Mersenne Twister pseudorandom number generators MT2203 [:ref:`Matsumoto98 <onemath_rng_bibliography>`], [:ref:`Matsumoto00 <onemath_rng_bibliography>`].
+The mt2203 engine is the set of Mersenne Twister pseudorandom number generators MT2203 [:ref:`Matsumoto98 <onemath_rng_bibliography>`], [:ref:`Matsumoto00 <onemath_rng_bibliography>`].
+Coefficients are obtained by `the following tool`_. The amount of engines in the set (denoted `n_engines`) is implementation defined.
 
 .. _onemath_rng_mt2203_description:
 
 .. rubric:: Description
 
-The set of 6024 basic pseudorandom number generators MT2203 is a natural addition to the MT19937 generator. MT2203 generators are intended for use in large scale Monte Carlo simulations performed on multi-processor computer systems.
+The set of basic pseudorandom number generators MT2203 is a natural addition to the MT19937 generator.
+MT2203 generators are intended for use in large scale Monte Carlo simulations performed on multi-processor computer systems.
 
 .. container:: section
 
     .. rubric:: Generation algorithm
 
-    For :math:`j = 1,..., 6024`:
+    For :math:`j = 1,..., n_engines`:
 
     :math:`x_{n, j} =x_{n - (69 - 34), j} \oplus ( (x_{n - 69, j} \& 0xFFFFFFE0) | (x_{n + 69 + 1, j} \& 0x1F) ) A_{j}`
 
@@ -140,14 +142,14 @@ class mt2203
             The initial conditions of the generator state. The initialization algorithm described in [:ref:`MT2203 <onemath_rng_bibliography>`].
 
         engine_idx
-            The index of the set 1, ..., 6024.
+            The index of the set 1, ..., n_engines.
 
     .. container:: section
 
         .. rubric:: Throws
 
         oneapi::math::invalid_argument
-            Exception is thrown when :math:`idx > 6024`
+            Exception is thrown when :math:`idx > n_engines`
 
     .. _`mt2203(sycl::queue queue, std::initializer_list<std::uint32_t> seed)`:
 
@@ -182,7 +184,7 @@ class mt2203
             The initial conditions of the generator state. The initialization algorithm described in [:ref:`MT2203 <onemath_rng_bibliography>`].
 
         engine_idx
-            The index of the set 1, ..., 6024.
+            The index of the set 1, ..., n_engines.
 
     .. _`mt2203(const mt2203& other)`:
 
@@ -237,3 +239,5 @@ class mt2203
             Valid ``mt2203`` r-value object. The ``queue`` and state of the other engine is moved to the current engine.
 
 **Parent topic:** :ref:`onemath_rng_engines_basic_random_number_generators`
+
+.. _`the following reference`: https://www.math.sci.hiroshima-u.ac.jp/m-mat/MT/DC/dc.html


### PR DESCRIPTION
In general, the amount of Mersenne Twister pseudorandom number generators mustn't be specified as concrete number. Implementors need to have freedom in terms of how much Mersenne Twister generators to use