### PR TITLE
[oneDPL] Fix the function signatures to not require std::projected_value_t

### DIFF
--- a/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
+++ b/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
@@ -47,7 +47,7 @@ of parallel range algorithms.
 
    // C++20 analogue of std::projected_value_t; exposition only
    template<typename I, typename Proj>
-   using projected-value-type = std::remove_cvref_t<std::invoke_result_t<Proj&, std::iter_value_t<I>&>>;
+   using /*projected-value-type*/ = std::remove_cvref_t<std::invoke_result_t<Proj&, std::iter_value_t<I>&>>;
 
 Whole Sequence Operations
 +++++++++++++++++++++++++
@@ -94,7 +94,7 @@ Whole Sequence Operations
     // count
     template <typename ExecutionPolicy, std::ranges::random_access_range R,
               typename Proj = std::identity,
-              typename T = projected-value-type<std::ranges::iterator_t<R>, Proj>>
+              typename T = /*projected-value-type*/<std::ranges::iterator_t<R>, Proj>>
       requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>> &&
                std::ranges::sized_range<R> &&
                std::indirect_binary_predicate< std::ranges::equal_to,
@@ -126,7 +126,7 @@ Element Search Operations
     // find
     template <typename ExecutionPolicy, std::ranges::random_access_range R,
               typename Proj = std::identity,
-              typename T = projected-value-type<std::ranges::iterator_t<R>, Proj>>
+              typename T = /*projected-value-type*/<std::ranges::iterator_t<R>, Proj>>
       requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>> &&
                std::ranges::sized_range<R> &&
                std::indirect_binary_predicate< std::ranges::equal_to,
@@ -221,7 +221,7 @@ Sequence Search and Comparison
     // search_n
     template<typename ExecutionPolicy, std::ranges::random_access_range R,
              typename Pred = std::ranges::equal_to, typename Proj = std::identity,
-             typename T = projected-value-type<std::ranges::iterator_t<R>, Proj>>
+             typename T = /*projected-value-type*/<std::ranges::iterator_t<R>, Proj>>
       requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>> &&
                std::ranges::sized_range<R> &&
                std::indirectly_comparable< std::ranges::iterator_t<R>, const T*, Pred, Proj >

--- a/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
+++ b/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
@@ -37,6 +37,18 @@ The following differences to the standard C++ range algorithms apply:
 Except for these differences, the signatures of parallel range algorithms correspond to the working draft
 of the next edition of the C++ standard (C++26).
 
+Auxiliary definitions
++++++++++++++++++++++
+
+The following auxiliary entities are only defined for the purpose of exposition, to aid the specification
+of parallel range algorithms.
+
+.. code:: cpp
+
+   // C++20 analogue of std::projected_value_t; exposition only
+   template<typename I, typename Proj>
+   using projected-value-type = std::remove_cvref_t<std::invoke_result_t<Proj&, std::iter_value_t<I>&>>;
+
 Whole Sequence Operations
 +++++++++++++++++++++++++
 
@@ -82,7 +94,7 @@ Whole Sequence Operations
     // count
     template <typename ExecutionPolicy, std::ranges::random_access_range R,
               typename Proj = std::identity,
-              typename T = std::projected_value_t<std::ranges::iterator_t<R>, Proj>>
+              typename T = projected-value-type<std::ranges::iterator_t<R>, Proj>>
       requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>> &&
                std::ranges::sized_range<R> &&
                std::indirect_binary_predicate< std::ranges::equal_to,
@@ -114,7 +126,7 @@ Element Search Operations
     // find
     template <typename ExecutionPolicy, std::ranges::random_access_range R,
               typename Proj = std::identity,
-              typename T = std::projected_value_t<std::ranges::iterator_t<R>, Proj>>
+              typename T = projected-value-type<std::ranges::iterator_t<R>, Proj>>
       requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>> &&
                std::ranges::sized_range<R> &&
                std::indirect_binary_predicate< std::ranges::equal_to,
@@ -209,7 +221,7 @@ Sequence Search and Comparison
     // search_n
     template<typename ExecutionPolicy, std::ranges::random_access_range R,
              typename Pred = std::ranges::equal_to, typename Proj = std::identity,
-             typename T = std::projected_value_t<std::ranges::iterator_t<R>, Proj>>
+             typename T = projected-value-type<std::ranges::iterator_t<R>, Proj>>
       requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>> &&
                std::ranges::sized_range<R> &&
                std::indirectly_comparable< std::ranges::iterator_t<R>, const T*, Pred, Proj >

--- a/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
+++ b/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
@@ -37,7 +37,7 @@ The following differences to the standard C++ range algorithms apply:
 Except for these differences, the signatures of parallel range algorithms correspond to the working draft
 of the next edition of the C++ standard (C++26).
 
-Auxiliary definitions
+Auxiliary Definitions
 +++++++++++++++++++++
 
 The following auxiliary entities are only defined for the purpose of exposition, to aid the specification


### PR DESCRIPTION
Another oversight found in the signatures of range algorithms: `std::projected_value_t` requires C++26.

To overcome the issue, it is replaced with an analogous alias added only for exposition (i.e., not as a public API) and defined in terms of C++20.

For comparison, this is the standard definition of `std::projected_value_t`:

```c++
template<indirectly_readable I, indirectly_regular_unary_invocable<I> Proj>
using projected_value_t = // freestanding
  remove_cvref_t<invoke_result_t<Proj&, iter_value_t<I>&>>;
```

It's a backward-compatible bug fix. Ideally it should be added to a revision of the specification v1.4.