### PR TITLE
[oneDPL] Indirectly Device Accessible Iterator Customization Point and Public Trait

### DIFF
--- a/source/elements/oneDPL/source/parallel_api/execution_policies.rst
+++ b/source/elements/oneDPL/source/parallel_api/execution_policies.rst
@@ -99,11 +99,11 @@ to run algorithms on a SYCL device. When an algorithm runs with ``device_policy`
 it is capable of processing SYCL buffers (passed via ``oneapi::dpl::begin/end``),
 data in the host memory and data in Unified Shared Memory (USM), including device USM.
 Data placed in the host memory and USM can be passed to oneDPL algorithms
-as pointers and random access iterators. oneDPL provides some :ref:`iterators <iterators>` which are
-compatible with algorithms when using a ``device_policy``. Custom iterators may also be used but users should
+as pointers and random access iterators. oneDPL provides some :ref:`iterators <iterators>` that are
+compatible with algorithms when using a ``device_policy``. Custom iterators may also be used, but users should
 ensure that those iterators have a defined :ref:`"passed directly" customization point <iterators-passed-directly>`
-to avoid unnecessary data movement. The iterators must also be SYCL device copyable to be used with
-algorithms using a ``device_policy``. The way to transfer data from the host memory
+to avoid unnecessary data movement. The iterators must also be SYCL device-copyable to be used with
+algorithms utilizing a ``device_policy``. The way to transfer data from the host memory
 to a device and back is unspecified; per-element data movement to/from a temporary storage
 is a possible valid implementation.
 

--- a/source/elements/oneDPL/source/parallel_api/execution_policies.rst
+++ b/source/elements/oneDPL/source/parallel_api/execution_policies.rst
@@ -99,12 +99,8 @@ to run algorithms on a SYCL device. When an algorithm runs with ``device_policy`
 it is capable of processing SYCL buffers (passed via ``oneapi::dpl::begin/end``),
 data in the host memory and data in Unified Shared Memory (USM), including device USM.
 Data placed in the host memory and USM can be passed to oneDPL algorithms
-as pointers and random access iterators. oneDPL provides some :ref:`iterators <iterators>` that are
-compatible with algorithms when using a ``device_policy``. Custom iterators may also be used, but users should
-ensure that those iterators have a defined :ref:`"passed directly" customization point <iterators-passed-directly>`
-to avoid unnecessary data movement. The iterators must also be SYCL device-copyable to be used with
-algorithms utilizing a ``device_policy``. The way to transfer data from the host memory
-to a device and back is unspecified; per-element data movement to/from a temporary storage
+as pointers and random access iterators, please see :ref:`iterators <iterators>`. The way to transfer data from the host
+memory to a device and back is unspecified; per-element data movement to/from a temporary storage
 is a possible valid implementation.
 
 The ``KernelName`` template parameter, also aliased as ``kernel_name`` within the class template,

--- a/source/elements/oneDPL/source/parallel_api/execution_policies.rst
+++ b/source/elements/oneDPL/source/parallel_api/execution_policies.rst
@@ -99,9 +99,9 @@ to run algorithms on a SYCL device. When an algorithm runs with ``device_policy`
 it is capable of processing SYCL buffers (passed via ``oneapi::dpl::begin/end``),
 data in the host memory and data in Unified Shared Memory (USM), including device USM.
 Data placed in the host memory and USM can be passed to oneDPL algorithms
-as pointers and random access iterators, please see :ref:`iterators <iterators>`. The way to transfer data from the host
-memory to a device and back is unspecified; per-element data movement to/from a temporary storage
-is a possible valid implementation.
+as pointers and random access iterators, including :doc:`oneDPL iterators <iterators>`. The way to transfer data from
+the host memory to a device and back is unspecified; per-element data movement to/from a temporary storage is a possible
+valid implementation.
 
 The ``KernelName`` template parameter, also aliased as ``kernel_name`` within the class template,
 is to explicitly provide a name for SYCL kernels executed by an algorithm the policy is passed to.

--- a/source/elements/oneDPL/source/parallel_api/execution_policies.rst
+++ b/source/elements/oneDPL/source/parallel_api/execution_policies.rst
@@ -99,7 +99,11 @@ to run algorithms on a SYCL device. When an algorithm runs with ``device_policy`
 it is capable of processing SYCL buffers (passed via ``oneapi::dpl::begin/end``),
 data in the host memory and data in Unified Shared Memory (USM), including device USM.
 Data placed in the host memory and USM can be passed to oneDPL algorithms
-as pointers and random access iterators. The way to transfer data from the host memory
+as pointers and random access iterators. oneDPL provides some :ref:`iterators <iterators>` which are
+compatible with algorithms when using a ``device_policy``. Custom iterators may also be used but users should
+ensure that those iterators have a defined :ref:`"passed directly" customization point <iterators-passed-directly>`
+to avoid unnecessary data movement. The iterators must also be SYCL device copyable to be used with
+algorithms using a ``device_policy``. The way to transfer data from the host memory
 to a device and back is unspecified; per-element data movement to/from a temporary storage
 is a possible valid implementation.
 

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -362,8 +362,9 @@ using the set of source iterators provided.
 
 Other Iterators
 +++++++++++++++
-Pointers are assumed to be USM shared or device memory pointers and are *indirectly device accessible*.
-Pointers are trivially copyable and therefore SYCL device-copyable.
+Pointers are assumed to be USM shared or device memory pointers when used in combination with an algorithm with a
+``device_policy`` and are *indirectly device accessible*. Pointers are trivially copyable and therefore SYCL
+device-copyable.
 
 ``std::reverse_iterator<IteratorT>`` is an ``AdaptingIteratorSource`` if ``IteratorT`` is an ``AdaptingIteratorSource``.
 ``std::reverse_iterator<IteratorT>`` is an *indirectly device accessible iterator* if ``IteratorT`` is an *indirectly

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -379,7 +379,7 @@ Pointers are trivially copyable and therefore SYCL device-copyable.
 Customization For User Defined Iterators
 ++++++++++++++++++++++++++++++++++++++++
 oneDPL provides a mechanism to indicate whether custom iterators are *indirectly device accessible* by defining an
- Argument-Dependent Lookup (ADL) based customization point, ``is_onedpl_indirectly_device_accessible``.
+Argument-Dependent Lookup (ADL) based customization point, ``is_onedpl_indirectly_device_accessible``.
 
 ADL-based Customization Point: ``is_onedpl_indirectly_device_accessible``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -11,19 +11,22 @@ Iterators
 Requirements For Iterator Use With Device Policies
 ++++++++++++++++++++++++++++++++++++++++++++++++++
 Iterator are, by default, not assumed to refer to content which is accessible on the device which requires that content
-to be copied to the device prior to being used inside a `SYCL`_ kernel. We define iterators to be "indirectly device
-accessible iterators" when they can inherently be dereferenced on the device in a SYCL kernel. When using oneDPL
-algorithms with a ``device_policy``, "indirectly device accessible iterators" avoid unnecessary data movement when
-provided as input or output arguments.
+to be copied to the device prior to being used inside a `SYCL`_ kernel. We define the term "indirectly device
+accessible" to mean representing data which is accessible on the device within a SYCL kernel. "Indirectly device
+accessible iterators" are iterators which can inherently be dereferenced on the device within a SYCL kernel.
+:doc:`*buffer position objects* <buffer_wrappers>` returned by ``oneapi::dpl::begin`` and ``oneapi::dpl::end`` are not
+iterators, but they are "indirectly device accessible" because they represent data which is accessible on the device.
+When using oneDPL algorithms with a ``device_policy``, "indirectly device accessible" types avoid unnecessary data
+movement when provided as input or output arguments.
 
-Examples of "indirectly device accessible iterators" include SYCL USM shared or device memory, or iterator types like
+Examples of "indirectly device accessible" iterators include SYCL USM shared or device memory, or iterator types like
 ``counting_iterator`` or ``discard_iterator`` that do not require any data to be copied to the device to be used in a
-SYCL kernel. An example of an iterator which does not refer to "indirectly device accessible" is a ``std::vector``
-iterator, which requires the data to be copied to the device in some way prior to usage in a SYCL kernel within
-algorithms used with a ``device_policy``.
+SYCL kernel. An example of an iterator type which is not "indirectly device accessible" is a ``std::vector`` iterator,
+with a host allocator which requires the data to be copied to the device in some way prior to usage in a SYCL kernel
+within algorithms used with a ``device_policy``.
 
-When used as input or output with algorithms using a ``device_policy`` "indirectly device accessible iterators" must
-also be SYCL device-copyable, as defined by the SYCL Specification.
+"Indirectly device accessible" types which are iterators must also be SYCL device-copyable to be used as input or output
+for oneDPL algorithms using a ``device_policy``.
 
 oneDPL Iterators
 ++++++++++++++++
@@ -201,6 +204,9 @@ to index into the value set defined by the source iterator. The resulting lvalue
 as the result of the operator.
 
 ``permutation_iterator`` is SYCL device-copyable if both the ``SourceIterator`` and the ``IndexMap``
+are SYCL device-copyable. ``permutation_iterator`` is "indirectly device accessible" if both the
+``SourceIterator`` and the ``IndexMap`` are "indirectly device accessible".
+
 are SYCL device-copyable. ``permutation_iterator`` is an "indirectly device accessible iterator" if both the
 ``SourceIterator`` and the ``IndexMap`` are "indirectly device accessible iterators".
 
@@ -326,8 +332,8 @@ source iterators over which the ``zip_iterator`` is defined. The arithmetic oper
 operation were applied to each of these iterators. The types ``T`` within the template pack 
 ``Iterators...`` must satisfy ``AdaptingIteratorSource``.
 
-``zip_iterator`` is SYCL device-copyable if all the source iterators are SYCL device-copyable, and
-is an "indirectly device accessible iterator" if all the source iterators are "indirectly device accessible iterators".
+``zip_iterator`` is SYCL device-copyable if all the source iterators are SYCL device-copyable, and is an "indirectly
+device accessible iterator" if all the source iterators are "indirectly device accessible iterators".
 
 .. code:: cpp
 
@@ -359,22 +365,22 @@ defining an Argument-Dependent Lookup (ADL) based customization point, ``is_oned
 oneDPL also defines a public trait, ``is_indirectly_device_accessible[_v]`` to indicate whether an iterator is an
 "indirectly device accessible iterators".
 
-oneDPL queries this information at compile time to determine how to handle iterator types when they are passed to
-algorithms with a ``device_policy`` to avoid unnecessary data movement.
+oneDPL queries this information at compile time to determine how to handle input and output types when they are passed
+to oneDPL algorithms with a ``device_policy`` to avoid unnecessary data movement.
 
 ADL Customization Point: ``is_onedpl_indirectly_device_accessible``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A free function ``is_onedpl_indirectly_device_accessible(IteratorT)`` may be defined, which accepts an argument
-of type ``IteratorT`` and returns a type with the base characteristic of ``std::true_type`` if ``IteratorT`` refers to
-"indirectly device accessible", or otherwise returns a type with the base characteristic of ``std::false_type``. The
-function must be discoverable by ADL.
+A free function ``is_onedpl_indirectly_device_accessible(T)`` may be defined, which accepts an argument of type ``T``
+and returns a type with the base characteristic of ``std::true_type`` if ``T`` represents "indirectly device accessible"
+content, or otherwise returns a type with the base characteristic of ``std::false_type``. The function must be
+discoverable by ADL.
 
-The function ``is_onedpl_indirectly_device_accessible`` may be used by oneDPL to determine if the iterator refers
-to "indirectly device accessible" by interrogating its return type at compile-time only. Overloads may be provided as
-forward declarations only, without a body defined. ADL is used to determine which function overload to use according to
-the rules in the `C++ Standard`_. Therefore, derived iterator types without an overload for their exact type will match
-their most specific base iterator type if such an overload exists.
+The function ``is_onedpl_indirectly_device_accessible`` may be used by oneDPL to determine if the type represents
+"indirectly device accessible" content by interrogating its return type at compile-time only. Overloads may be provided
+as forward declarations only, without a body defined. ADL is used to determine which function overload to use according
+to the rules in the `C++ Standard`_. Therefore, derived iterator types without an overload for their exact type will
+match their most specific base iterator type if such an overload exists.
 
 Public Trait: ``oneapi::dpl::is_indirectly_device_accessible[_v]``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -391,8 +397,8 @@ The following class template and variable template are defined in ``<oneapi/dpl/
     inline constexpr bool is_indirectly_device_accessible_v = is_indirectly_device_accessible<T>::value;
 
 ``template <typename T> oneapi::dpl::is_indirectly_device_accessible`` is a type which has the base characteristic
-of ``std::true_type`` if ``T``  refers to "indirectly device accessible", otherwise it has the base characteristic of
-``std::false_type``.
+of ``std::true_type`` if ``T`` represents "indirectly device accessible" content, otherwise it has the base
+characteristic of ``std::false_type``.
 
 
 
@@ -411,7 +417,7 @@ of the iterator class.
     {
         struct accessible_it
         {
-            /* unspecified user definition of a iterator which refers to "indirectly device accessible" */
+            /* unspecified user definition of a iterator which represents "indirectly device accessible" content*/
         };
 
         std::true_type
@@ -419,7 +425,7 @@ of the iterator class.
 
         struct inaccessible_it
         {
-            /* unspecified user definition of iterator which doesn't refer to "indirectly device accessible" */
+            /* unspecified user definition of iterator which doesn't represent "indirectly device accessible" content */
         };
 
         // This could be omitted. It would rely upon the default implementation with the same result

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -306,26 +306,29 @@ using the set of source iterators provided.
 
 .. _iterators-device-accessible:
 
-Iterators of Device Accessible Content with Device Policies
------------------------------------------------------------
+Device Accessible Content Iterators with Device Policies
+--------------------------------------------------------
 
 Iterator are, by default, not assumed to refer to content which is accessible on the device which requires the content
-to be copied to the device prior to being used inside a `SYCL`_ kernel. We say that iterators are of "device accessible
-content" when they can inherently be dereferenced on the device in a SYCL kernel. When using algorithms with a 
-``device_policy``, iterators of "device accessible content" avoid unnecessary data movement when provided as input or
-output arguments.
+to be copied to the device prior to being used inside a `SYCL`_ kernel. We define that iterators to be  "device
+accessible content iterators" when they can inherently be dereferenced on the device in a SYCL kernel. When using oneDPL
+algorithms with a ``device_policy``, "device accessible content iterators" avoid unnecessary data movement when provided
+as input or output arguments.
 
-Examples of iterators of "device accessible content" include SYCL USM shared or device memory, or iterator types like
+Examples of "device accessible content iterators" include SYCL USM shared or device memory, or iterator types like
 ``counting_iterator`` or ``discard_iterator`` that do not require any data to be copied to the device to be used in a
 SYCL kernel. An example of an iterator which does not refer to "device accessible content" is a ``std::vector``
 iterator, which requires the data to be copied to the device in some way prior to usage in a SYCL kernel within
 algorithms used with a ``device_policy``.
 
-oneDPL provides a mechanism to define whether custom iterator types are of "device accessible content" to SYCL kernels.
+oneDPL provides a mechanism to define whether custom iterators are "device accessible content iterators" by defining
+a Argument-Dependent Lookup (ADL) customization point, ``is_onedpl_device_accessible_content_iterator``. This allows
+users to define rules for their own iterators to be "device accessible content iterators" or not. oneDPL also defines a
+public trait, ``is_device_accessible_content_iterator[_v]`` to indicate whether an iterator is a "device accessible
+content iterator".
+
 oneDPL queries this information at compile time to determine how to handle the iterator type when passed to algorithms
-with a ``device_policy``. This is important because it allows oneDPL to avoid unnecessary data movement. This is
-achieved using the ``is_onedpl_device_accessible_content_iterator`` Argument-Dependent Lookup (ADL) customization point
-and the public trait ``is_device_accessible_content_iterator[_v]``.
+with a ``device_policy``. This is important because it allows oneDPL to avoid unnecessary data movement.
 
 ADL Customization Point: ``is_onedpl_device_accessible_content_iterator``
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -343,28 +346,29 @@ declarations only, without a body defined. ADL lookup is used to determine which
 the rules in the `C++ Standard`_. Therefore, derived iterator types without an overload for their exact type will match
 their most specific base iterator type if such an overload exists.
 
-The default implementation of ``is_onedpl_device_accessible_content_iterator`` marks the following iterators referring
-to "device accessible content":
+The default implementation of ``is_onedpl_device_accessible_content_iterator`` marks the following iterators as to
+"device accessible content iterators":
 * Pointers (to handle USM pointers)
 * Iterators with the ``using is_passed_directly = std::true_type`` trait
 * Iterators to USM shared allocated ``std::vector``-s when the allocator type is knowable from the iterator type
 * ``std::reverse_iterator<IteratorT>`` when ``IteratorT`` refers to "device accessible content"
 
-oneDPL defines its provided iterators as referring to "device accessible content" as follows:
-* ``counting_iterator`` and ``discard_iterator``: Always refer to "device accessible content".
-* ``permutation_iterator``:  Refers to "device accessible content" if both its source iterator and its index map refer
-to "device accessible content".
-* ``transform_iterator``:  Refers to "device accessible content" if its source iterator refers to "device accessible
-content".
-* ``zip_iterator``:  Refers to "device accessible content" if all base iterators refer to to "device accessible
-content".
+oneDPL defines rules for the provided iterators as follows:
+* ``counting_iterator``: Always a "device accessible content iterator"
+* ``discard_iterator``: Always a "device accessible content iterator"
+* ``permutation_iterator``:  "Device accessible content iterator" if both its source iterator and its index map are 
+"device accessible content iterators"
+* ``transform_iterator``:  "Device accessible content iterator" if its source iterator is a "device accessible content
+iterator"
+* ``zip_iterator``:  "Device accessible content iterator" if all base iterators are "device accessible content
+iterators"
 
 
 Public Trait: ``oneapi::dpl::is_device_accessible_content_iterator[_v]``
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 The public trait ``oneapi::dpl::is_device_accessible_content_iterator[_v]`` can be used to query whether an iterator
-refers to "device accessible content". The trait is defined in ``<oneapi/dpl/iterator>``.
+is a "device accessible content iterator". The trait is defined in ``<oneapi/dpl/iterator>``.
 
 ``oneapi::dpl::is_device_accessible_content_iterator<T>`` evaluates to a type with the characteristics of
 ``std::true_type`` if ``T``  refers to "device accessible content", otherwise it evaluates to a type with the
@@ -376,9 +380,9 @@ refers to "device accessible content", otherwise it evaluates to ``false``.
 Device Copyability of Iterators
 +++++++++++++++++++++++++++++++
 
-Iterators that refer to "device accessible content" and are used as input or output with algorithms using a
-``device_policy`` must also be SYCL device-copyable, as defined by the SYCL Specification. oneDPL provides
-specializations of ``sycl::is_device_copyable`` for each of its provided iterator types.
+"Device accessible content iterators" which are used as input or output with algorithms using a ``device_policy`` must
+also be SYCL device-copyable, as defined by the SYCL Specification. oneDPL provides specializations of
+``sycl::is_device_copyable`` for each of its provided iterator types.
 
 The rules are as follows:
 * ``counting_iterator``: Always device-copyable.

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -360,14 +360,14 @@ device accessible* if all the source iterators are *indirectly device accessible
 ``make_zip_iterator`` constructs and returns an instance of ``zip_iterator``
 using the set of source iterators provided.
 
-Other Supported Iterators
-+++++++++++++++++++++++++
+Other Iterators
++++++++++++++++
+Pointers are assumed to be USM shared or device memory pointers and are *indirectly device accessible*.
+Pointers are trivially copyable and therefore SYCL device-copyable.
+
 ``std::reverse_iterator<IteratorT>`` is an ``AdaptingIteratorSource`` if ``IteratorT`` is an ``AdaptingIteratorSource``.
 ``std::reverse_iterator<IteratorT>`` is an *indirectly device accessible iterator* if ``IteratorT`` is an *indirectly
 device accessible iterator*.
-
-Pointers are assumed to be USM shared or device memory pointers and are *indirectly device accessible*.
-Pointers are trivially copyable and therefore SYCL device-copyable.
 
 Whether or not ``std::vector::iterator`` are *indirectly device accessible* is implementation defined, and may depend on
 the allocator used to create the vector, as well as the specific implementation of ``std::vector``.

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -389,9 +389,9 @@ The following class template and variable template are defined in ``<oneapi/dpl/
     inline constexpr bool is_device_accessible_content_iterator_v =
         is_device_accessible_content_iterator<T>::value;
 
-``oneapi::dpl::is_device_accessible_content_iterator<T>`` evaluates to a type with the characteristics of
-``std::true_type`` if ``T``  refers to "device accessible content", otherwise it evaluates to a type with the
-characteristics of ``std::false_type``.
+``template <typename T> oneapi::dpl::is_device_accessible_content_iterator<T>`` evaluates to a type with the 
+characteristics of ``std::true_type`` if ``T``  refers to "device accessible content", otherwise it evaluates to a type
+with the characteristics of ``std::false_type``.
 
 
 

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -207,8 +207,8 @@ as the result of the operator.
 are SYCL device-copyable. ``permutation_iterator`` is "indirectly device accessible" if both the
 ``SourceIterator`` and the ``IndexMap`` are "indirectly device accessible".
 
-are SYCL device-copyable. ``permutation_iterator`` is an "indirectly device accessible iterator" if both the
-``SourceIterator`` and the ``IndexMap`` are "indirectly device accessible iterators".
+When using ``permutation_iterator`` in combination with an algorithm with a ``device_policy``, ``SourceIterator`` must
+be "indirectly device accessible".
 
 .. code:: cpp
 

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -369,7 +369,7 @@ Other Supported Iterators
 ``std::reverse_iterator<IteratorT>`` is an *indirectly device accessible iterator* if ``IteratorT`` is an *indirectly
 device accessible iterator*. The SYCL device-copyable requirement of ``std::reverse_iterator<IteratorT>`` for use in
 algorithms with a ``device_policy`` relies upon the trivial copyability of ``IteratorT`` and the specific implementation
-of ``std::reverse_iterator``. oneDPL does not specialize ``sycl::is_device_copyable`` for ``std::reverse_iterator``.
+of ``std::reverse_iterator``. 
 
 Pointers are assumed to be USM shared or device memory pointers and are *indirectly device accessible*.
 Pointers are trivially copyable and therefore SYCL device-copyable.

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -397,7 +397,7 @@ source iterator component types. Refer to the example below.
 Example
 ^^^^^^^
 
-The following example shows how to define a customization for `is_indirectly_device_accessible` trait for a simple
+The following example shows how to define a customization for ``is_indirectly_device_accessible`` trait for a simple
 user defined iterator.  It also shows a more complicated example where the customization is defined as a hidden friend
 of the iterator class.
 

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -400,10 +400,6 @@ The following class template and variable template are defined in ``<oneapi/dpl/
 of ``std::true_type`` if ``T`` represents "indirectly device accessible" content, otherwise it has the base
 characteristic of ``std::false_type``.
 
-
-
-
-
 Example
 ^^^^^^^
 

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -353,7 +353,7 @@ oneDPL defines the "passed directly" behavior for its custom iterators as follow
 
 
 Public Trait: ``is_passed_directly_to_device[_v]``
-++++++++++++++++++++++++++++++++++++++++++++++
+++++++++++++++++++++++++++++++++++++++++++++++++++
 
 The public trait ``oneapi::dpl::is_passed_directly_to_device[_v]`` can be used to query whether an iterator type is
 "passed directly" to SYCL kernels. The trait is defined in ``<oneapi/dpl/iterator>``.

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -381,12 +381,12 @@ The following class template and variable template are defined in ``<oneapi/dpl/
 ``oneapi::dpl``:
 
 .. code:: cpp
-    template <typename T>
-    struct is_device_accessible_content_iterator;
 
-    template <typename T>
-    inline constexpr bool is_device_accessible_content_iterator_v =
-        is_device_accessible_content_iterator<T>::value;
+template <typename T>
+struct is_device_accessible_content_iterator{ /* see below */ };
+
+template <typename T>
+inline constexpr bool is_device_accessible_content_iterator_v = is_device_accessible_content_iterator<T>::value;
 
 ``template <typename T> oneapi::dpl::is_device_accessible_content_iterator<T>`` evaluates to a type with the 
 characteristics of ``std::true_type`` if ``T``  refers to "device accessible content", otherwise it evaluates to a type

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -312,19 +312,20 @@ Iterator Compatibility with Device Policies
 The iterators described here are compatible with algorithms when using a ``device_policy``, but some additional
 considerations apply. Iterators used with algorithms using a ``device_policy`` must be SYCL device-copyable as defined
 by the `SYCL`_ Specification. oneDPL provides specializations for each iterator type of ``sycl::is_device_copyable``.
-Those rules are as follows:
+
+The rules are as follows:
 * ``counting_iterator``: Always device-copyable.
 * ``discard_iterator``: Always device-copyable.
-* ``permutation_iterator``: Device-copyable if both the source iterator and index map are device-copyable.
+* ``permutation_iterator``: Device-copyable if both the source iterator and the index map are device-copyable.
 * ``transform_iterator``: Device-copyable if the source iterator is device-copyable.
 * ``zip_iterator``: Device-copyable if all base iterators are device-copyable.
 
-To use algorithms with a ``device_policy`` efficiently, minimizing unnecessary data movement is very important. Toward
-this end, oneDPL provides a mechanism to define whether custom iterator types are of "device accessible content".
+To use algorithms with a ``device_policy`` efficiently, minimizing unnecessary data movement is very important. To
+support this, oneDPL provides a mechanism to define whether custom iterator types are of "device accessible content."
 
 Users may provide their own custom iterators as input to algorithms with a ``device_policy``, but they must ensure that
-the iterators are ``sycl::is_device_copyable``, and should also ensure that the iterators are
-of "device accessible content" if they are to be used efficiently.
+the iterators are ``sycl::is_device_copyable``. Additionally, for best performance, users should ensure that the
+iterators are of "device accessible content", and are marked as such using the customization point described below.
 
 Customization Point for Iterators of Device Accessible Content
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -364,17 +364,13 @@ Other Supported Iterators
 +++++++++++++++++++++++++
 ``std::reverse_iterator<IteratorT>`` is an ``AdaptingIteratorSource`` if ``IteratorT`` is an ``AdaptingIteratorSource``.
 ``std::reverse_iterator<IteratorT>`` is an *indirectly device accessible iterator* if ``IteratorT`` is an *indirectly
-device accessible iterator*. The SYCL device-copyable requirement of ``std::reverse_iterator<IteratorT>`` for use in
-algorithms with a ``device_policy`` relies upon the trivial copyability of ``IteratorT`` and the specific implementation
-of ``std::reverse_iterator``. 
+device accessible iterator*.
 
 Pointers are assumed to be USM shared or device memory pointers and are *indirectly device accessible*.
 Pointers are trivially copyable and therefore SYCL device-copyable.
 
 Whether or not ``std::vector::iterator`` are *indirectly device accessible* is implementation defined, and may depend on
-the allocator used to create the vector, as well as the specific implementation of ``std::vector``. The SYCL
-device-copyable requirement ``std::vector::iterator`` for use in algorithms with a ``device_policy`` relies upon the
-trivial copyability of the specific implementation ``std::vector``.
+the allocator used to create the vector, as well as the specific implementation of ``std::vector``.
 
 .. _iterators-device-accessible:
 

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -14,17 +14,17 @@ Iterators and iterator-like types may or may not refer to content accessible wit
 The term *indirectly device accessible* refers to a type that represents content accessible on a device.
 An *indirectly device accessible iterator* is such a type that can also be dereferenced within a SYCL kernel.
 
-An example of *indirectly device accessible iterators* include SYCL USM shared pointers which can inherently be used in
-a SYCL kernel. An example of an iterator type that is not *indirectly device accessible* is a random access iterator
+An example of indirectly device accessible iterators include SYCL USM shared pointers which can inherently be used in
+a SYCL kernel. An example of an iterator type that is not indirectly device accessible is a random access iterator
 referring to host allocated data because dereferencing it within a SYCL kernel would result in undefined behavior.
 
 :doc:`Buffer position objects <buffer_wrappers>` returned by ``oneapi::dpl::begin`` and ``oneapi::dpl::end`` are not
-iterators. However, they are *indirectly device accessible* because they represent data accessible on the device.
+iterators. However, they are indirectly device accessible because they represent data accessible on the device.
 
-When passed to oneDPL algorithms with a ``device_policy``, *indirectly device accessible iterator* types that are also
+When passed to oneDPL algorithms with a ``device_policy``, indirectly device accessible iterator types that are also
 random access iterators and satisfy *SYCL device-copyable* must not cause unnecessary data movement beyond what is
 required by the algorithm's semantics and what would be required to use the type directly within a SYCL kernel.
-*Indirectly device accessible* *buffer position objects* must not cause unnecessary data movement beyond what is
+Indirectly device accessible buffer position objects must not cause unnecessary data movement beyond what is
 required by the algorithm's semantics and what would be required by using an accessor to the buffer within a SYCL
 kernel.
 
@@ -43,7 +43,7 @@ The following class template and variable template are defined in ``<oneapi/dpl/
     inline constexpr bool is_indirectly_device_accessible_v = is_indirectly_device_accessible<T>::value;
 
 ``template <typename T> oneapi::dpl::is_indirectly_device_accessible`` is a type which has the base characteristic
-of ``std::true_type`` if ``T`` is *indirectly device accessible*. Otherwise, it has the base characteristic of
+of ``std::true_type`` if ``T`` is indirectly device accessible. Otherwise, it has the base characteristic of
 ``std::false_type``.
 
 oneDPL Iterators
@@ -107,7 +107,7 @@ counter; dereference operations cannot be used to modify the counter. The arithm
 operators of ``counting_iterator`` behave as if applied to the values of Integral type
 representing the counters of the iterator instances passed to the operators.
 
-``counting_iterator`` is SYCL device-copyable, and is an *indirectly device accessible iterator*.
+``counting_iterator`` is SYCL device-copyable, and is an indirectly device accessible iterator.
 
 .. code:: cpp
 
@@ -149,7 +149,7 @@ lvalue that may be assigned an arbitrary value. The assignment has no effect on 
 of ``discard_iterator`` behave as if applied to integer counter values maintained by the
 iterator instances to determine their position relative to each other.
 
-``discard_iterator`` is SYCL device-copyable, and is an *indirectly device accessible iterator*.
+``discard_iterator`` is SYCL device-copyable, and is an indirectly device accessible iterator.
 
 .. code:: cpp
 
@@ -200,11 +200,11 @@ to the index of the source iterator. The arithmetic and comparison operators of
 iterator instances to determine their position in the index map. 
 
 ``permutation_iterator`` is SYCL device-copyable if both the ``SourceIterator`` and the ``IndexMap``
-are SYCL device-copyable. ``permutation_iterator`` is *indirectly device accessible* if both the
-``SourceIterator`` and the ``IndexMap`` are *indirectly device accessible*.
+are SYCL device-copyable. ``permutation_iterator`` is indirectly device accessible if both the
+``SourceIterator`` and the ``IndexMap`` are indirectly device accessible.
 
 ``SourceIterator`` must satisfy ``AdaptingIteratorSource``. When using ``permutation_iterator`` in combination with an
-algorithm with a ``device_policy``, ``SourceIterator`` must be *indirectly device accessible*.
+algorithm with a ``device_policy``, ``SourceIterator`` must be indirectly device accessible.
 
 The type ``IndexMap`` must be one of the following:
 
@@ -287,7 +287,7 @@ source iterator itself. The template type ``Iterator`` must satisfy
 ``AdaptingIteratorSource``.
 
 ``transform_iterator`` is SYCL device-copyable if the source iterator is SYCL device-copyable, and
-is *indirectly device accessible* if the source iterator is *indirectly device accessible*.
+is indirectly device accessible if the source iterator is indirectly device accessible.
 
 .. code:: cpp
 
@@ -348,8 +348,8 @@ source iterators over which the ``zip_iterator`` is defined. The arithmetic oper
 operation were applied to each of these iterators. The types ``T`` within the template pack 
 ``Iterators...`` must satisfy ``AdaptingIteratorSource``.
 
-``zip_iterator`` is SYCL device-copyable if all the source iterators are SYCL device-copyable, and is *indirectly
-device accessible* if all the source iterators are *indirectly device accessible*.
+``zip_iterator`` is SYCL device-copyable if all the source iterators are SYCL device-copyable, and is indirectly
+device accessible if all the source iterators are indirectly device accessible.
 
 .. code:: cpp
 
@@ -363,26 +363,26 @@ using the set of source iterators provided.
 Other Iterators
 +++++++++++++++
 Pointers are assumed to be USM shared or device memory pointers when used in combination with an algorithm with a
-``device_policy`` and are *indirectly device accessible*. Pointers are trivially copyable and therefore SYCL
+``device_policy`` and are indirectly device accessible. Pointers are trivially copyable and therefore SYCL
 device-copyable.
 
-It is implementation defined whether other iterators are *indirectly device accessible*, including iterator types from
+It is implementation defined whether other iterators are indirectly device accessible, including iterator types from
 the `C++ Standard`_.
 
 .. _iterators-device-accessible:
 
 Customization For User Defined Iterators
 ++++++++++++++++++++++++++++++++++++++++
-oneDPL provides a mechanism to indicate whether custom iterators are *indirectly device accessible*.
+oneDPL provides a mechanism to indicate whether custom iterators are indirectly device accessible.
 
 Applications may define a free function ``is_onedpl_indirectly_device_accessible(T)``, which accepts an argument of
-type ``T`` and returns a type with the base characteristic of ``std::true_type`` if ``T`` is *indirectly device
-accessible*. Otherwise, it returns a type with the base characteristic of ``std::false_type``. The function must be
+type ``T`` and returns a type with the base characteristic of ``std::true_type`` if ``T`` is indirectly device
+accessible. Otherwise, it returns a type with the base characteristic of ``std::false_type``. The function must be
 discoverable by argument-dependent lookup (ADL). It may be provided as a forward declaration only, without defining a
 body.
 
 The return type of ``is_onedpl_indirectly_device_accessible`` is examined at compile time to determine if ``T`` is
-*indirectly device accessible*. The function overload to use must be selected with argument-dependent lookup.
+indirectly device accessible. The function overload to use must be selected with argument-dependent lookup.
 [*Note*: Therefore, according to the rules in the C++ Standard, a derived type for which there is no
 function overload will match its most specific base type for which an overload exists. -- *end note*]
 

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -197,8 +197,14 @@ defined by the source iterator provided, and whose iteration order over the dere
 is defined by either another iterator or a functor that maps the ``permutation_iterator`` index
 to the index of the source iterator. The arithmetic and comparison operators of
 ``permutation_iterator`` behave as if applied to integer counter values maintained by the
-iterator instances to determine their position in the index map. ``SourceIterator`` must satisfy
-``AdaptingIteratorSource``.
+iterator instances to determine their position in the index map. 
+
+``permutation_iterator`` is SYCL device-copyable if both the ``SourceIterator`` and the ``IndexMap``
+are SYCL device-copyable. ``permutation_iterator`` is *indirectly device accessible* if both the
+``SourceIterator`` and the ``IndexMap`` are *indirectly device accessible*.
+
+``SourceIterator`` must satisfy ``AdaptingIteratorSource``. When using ``permutation_iterator`` in combination with an
+algorithm with a ``device_policy``, ``SourceIterator`` must be *indirectly device accessible*.
 
 The type ``IndexMap`` must be one of the following:
 
@@ -220,13 +226,6 @@ as the result of the operator.
 to index into the index map. The corresponding value in the map is then used
 to index into the value set defined by the source iterator. The resulting lvalue is returned
 as the result of the operator.
-
-``permutation_iterator`` is SYCL device-copyable if both the ``SourceIterator`` and the ``IndexMap``
-are SYCL device-copyable. ``permutation_iterator`` is *indirectly device accessible* if both the
-``SourceIterator`` and the ``IndexMap`` are *indirectly device accessible*.
-
-When using ``permutation_iterator`` in combination with an algorithm with a ``device_policy``, ``SourceIterator`` must
-be *indirectly device accessible*.
 
 .. code:: cpp
 

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -10,23 +10,25 @@ Iterators
 
 Requirements For Iterator Use With Device Policies
 ++++++++++++++++++++++++++++++++++++++++++++++++++
-Iterator are, by default, not assumed to refer to content which is accessible on the device which requires that content
-to be copied to the device prior to being used inside a `SYCL`_ kernel. We define the term "indirectly device
-accessible" to mean representing data which is accessible on the device within a SYCL kernel. "Indirectly device
-accessible iterators" are iterators which can inherently be dereferenced on the device within a SYCL kernel.
-:doc:`*buffer position objects* <buffer_wrappers>` returned by ``oneapi::dpl::begin`` and ``oneapi::dpl::end`` are not
-iterators, but they are "indirectly device accessible" because they represent data which is accessible on the device.
-When using oneDPL algorithms with a ``device_policy``, "indirectly device accessible" types avoid unnecessary data
-movement when provided as input or output arguments.
+Iterators are not assumed to refer to content that is accessible on the device by default. Without direct knowledge
+that content is accessible on the device, oneDPL algorithms must copy the content to the device before being used inside
+a `SYCL`_ kernel, and then back from the device afterward. We define the term "indirectly device accessible" to mean 
+representing content that is accessible on the device within a SYCL kernel. "Indirectly device accessible iterators"
+are iterators that can inherently be dereferenced on the device within a SYCL kernel.
 
 Examples of "indirectly device accessible" iterators include SYCL USM shared or device memory, or iterator types like
 ``counting_iterator`` or ``discard_iterator`` that do not require any data to be copied to the device to be used in a
-SYCL kernel. An example of an iterator type which is not "indirectly device accessible" is a ``std::vector`` iterator,
-with a host allocator which requires the data to be copied to the device in some way prior to usage in a SYCL kernel
+SYCL kernel. An example of an iterator type that is not "indirectly device accessible" is a ``std::vector`` iterator
+with a host allocator, which requires the data to be copied to the device in some way before usage in a SYCL kernel
 within algorithms used with a ``device_policy``.
 
-"Indirectly device accessible" types which are iterators must also be SYCL device-copyable to be used as input or output
-for oneDPL algorithms using a ``device_policy``.
+:doc:`*buffer position objects* <buffer_wrappers>` returned by ``oneapi::dpl::begin`` and ``oneapi::dpl::end`` are not
+iterators, but they are "indirectly device accessible" because they represent data that is accessible on the device.
+When using oneDPL algorithms with a ``device_policy``, "indirectly device accessible" types avoid unnecessary data
+movement when provided as input or output arguments.
+
+"Indirectly device accessible iterators" must also be SYCL device-copyable to be used as input or output for oneDPL
+algorithms using a ``device_policy``.
 
 oneDPL Iterators
 ++++++++++++++++

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -376,9 +376,9 @@ refers to "device accessible content", otherwise it evaluates to ``false``.
 Device Copyability of Iterators
 +++++++++++++++++++++++++++++++
 
-Iterators referring to "device accessible content" used as input or output with algorithms using a ``device_policy``
-must also be SYCL device-copyable as defined by the SYCL Specification. oneDPL provides specializations for
-``sycl::is_device_copyable`` for each of its provide iterator types.
+Iterators that refer to "device accessible content" and are used as input or output with algorithms using a
+``device_policy`` must also be SYCL device-copyable, as defined by the SYCL Specification. oneDPL provides
+specializations of ``sycl::is_device_copyable`` for each of its provided iterator types.
 
 The rules are as follows:
 * ``counting_iterator``: Always device-copyable.

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -86,7 +86,7 @@ counter; dereference operations cannot be used to modify the counter. The arithm
 operators of ``counting_iterator`` behave as if applied to the values of Integral type
 representing the counters of the iterator instances passed to the operators.
 
-``counting_iterator`` are SYCL device-copyable, and are "device accessible content iterators".
+``counting_iterator`` is SYCL device-copyable, and is a "device accessible content iterator".
 
 .. code:: cpp
 
@@ -128,7 +128,7 @@ lvalue that may be assigned an arbitrary value. The assignment has no effect on 
 of ``discard_iterator`` behave as if applied to integer counter values maintained by the
 iterator instances to determine their position relative to each other.
 
-``discard_iterator`` are SYCL device-copyable, and are "device accessible content iterators".
+``discard_iterator`` is SYCL device-copyable, and is a "device accessible content iterator".
 
 .. code:: cpp
 
@@ -200,9 +200,9 @@ to index into the index map. The corresponding value in the map is then used
 to index into the value set defined by the source iterator. The resulting lvalue is returned
 as the result of the operator.
 
-``permutation_iterator`` are SYCL device-copyable if both the ``SourceIterator`` and the ``IndexMap``
-are SYCL device-copyable, and are "device accessible content iterators" if both the ``SourceIterator``
-and the ``IndexMap`` are "device accessible content iterators".
+``permutation_iterator`` is SYCL device-copyable if both the ``SourceIterator`` and the ``IndexMap``
+are SYCL device-copyable. ``permutation_iterator`` is a "device accessible content iterator" if both the
+``SourceIterator`` and the ``IndexMap`` are "device accessible content iterators".
 
 .. code:: cpp
 
@@ -328,7 +328,7 @@ operation were applied to each of these iterators. The types ``T`` within the te
 ``Iterators...`` must satisfy ``AdaptingIteratorSource``.
 
 ``zip_iterator`` is SYCL device-copyable if all the source iterators are SYCL device-copyable, and
-is "device accessible content iterator" if all the source iterators are "device accessible
+is a "device accessible content iterator" if all the source iterators are "device accessible
 content iterators".
 
 .. code:: cpp

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -10,19 +10,19 @@ Iterators
 
 Requirements For Iterator Use With Device Policies
 ++++++++++++++++++++++++++++++++++++++++++++++++++
-Iterator are, by default, not assumed to refer to content which is accessible on the device which requires the content
-to be copied to the device prior to being used inside a `SYCL`_ kernel. We define iterators to be "device accessible
-content iterators" when they can inherently be dereferenced on the device in a SYCL kernel. When using oneDPL algorithms
-with a ``device_policy``, "device accessible content iterators" avoid unnecessary data movement when provided as input
-or output arguments.
+Iterator are, by default, not assumed to refer to content which is accessible on the device which requires that content
+to be copied to the device prior to being used inside a `SYCL`_ kernel. We define iterators to be "indirectly device
+accessible iterators" when they can inherently be dereferenced on the device in a SYCL kernel. When using oneDPL
+algorithms with a ``device_policy``, "indirectly device accessible iterators" avoid unnecessary data movement when
+provided as input or output arguments.
 
-Examples of "device accessible content iterators" include SYCL USM shared or device memory, or iterator types like
+Examples of "indirectly device accessible iterators" include SYCL USM shared or device memory, or iterator types like
 ``counting_iterator`` or ``discard_iterator`` that do not require any data to be copied to the device to be used in a
-SYCL kernel. An example of an iterator which does not refer to "device accessible content" is a ``std::vector``
+SYCL kernel. An example of an iterator which does not refer to "indirectly device accessible" is a ``std::vector``
 iterator, which requires the data to be copied to the device in some way prior to usage in a SYCL kernel within
 algorithms used with a ``device_policy``.
 
-When used as input or output with algorithms using a ``device_policy`` "device accessible content iterators" must also
+When used as input or output with algorithms using a ``device_policy`` "indirectly device accessible iterators" must also
 be SYCL device-copyable, as defined by the SYCL Specification.
 
 oneDPL Iterators
@@ -86,7 +86,7 @@ counter; dereference operations cannot be used to modify the counter. The arithm
 operators of ``counting_iterator`` behave as if applied to the values of Integral type
 representing the counters of the iterator instances passed to the operators.
 
-``counting_iterator`` is SYCL device-copyable, and is a "device accessible content iterator".
+``counting_iterator`` is SYCL device-copyable, and is an "indirectly device accessible iterator".
 
 .. code:: cpp
 
@@ -128,7 +128,7 @@ lvalue that may be assigned an arbitrary value. The assignment has no effect on 
 of ``discard_iterator`` behave as if applied to integer counter values maintained by the
 iterator instances to determine their position relative to each other.
 
-``discard_iterator`` is SYCL device-copyable, and is a "device accessible content iterator".
+``discard_iterator`` is SYCL device-copyable, and is an "indirectly device accessible iterator".
 
 .. code:: cpp
 
@@ -201,8 +201,8 @@ to index into the value set defined by the source iterator. The resulting lvalue
 as the result of the operator.
 
 ``permutation_iterator`` is SYCL device-copyable if both the ``SourceIterator`` and the ``IndexMap``
-are SYCL device-copyable. ``permutation_iterator`` is a "device accessible content iterator" if both the
-``SourceIterator`` and the ``IndexMap`` are "device accessible content iterators".
+are SYCL device-copyable. ``permutation_iterator`` is an "indirectly device accessible iterator" if both the
+``SourceIterator`` and the ``IndexMap`` are "indirectly device accessible iterators".
 
 .. code:: cpp
 
@@ -265,8 +265,7 @@ source iterator itself. The template type ``Iterator`` must satisfy
 ``AdaptingIteratorSource``.
 
 ``transform_iterator`` is SYCL device-copyable if the source iterator is SYCL device-copyable, and
-is "device accessible content iterator" if the source iterator is a "device accessible
-content iterator".
+is "indirectly device accessible iterator" if the source iterator is an "indirectly device accessible iterators".
 
 .. code:: cpp
 
@@ -328,8 +327,7 @@ operation were applied to each of these iterators. The types ``T`` within the te
 ``Iterators...`` must satisfy ``AdaptingIteratorSource``.
 
 ``zip_iterator`` is SYCL device-copyable if all the source iterators are SYCL device-copyable, and
-is a "device accessible content iterator" if all the source iterators are "device accessible
-content iterators".
+is an "indirectly device accessible iterator" if all the source iterators are "indirectly device accessible iterators".
 
 .. code:: cpp
 
@@ -345,36 +343,36 @@ using the set of source iterators provided.
 Customization For User Defined Iterators
 ++++++++++++++++++++++++++++++++++++++++
 
-oneDPL provides a mechanism to indicate whether custom iterators are "device accessible content iterators" by defining
-an Argument-Dependent Lookup (ADL) based customization point, ``is_onedpl_device_accessible_content_iterator``. oneDPL
-also defines a public trait, ``is_device_accessible_content_iterator[_v]`` to indicate whether an iterator is a "device
-accessible content iterator".
+oneDPL provides a mechanism to indicate whether custom iterators are "indirectly device accessible iterators" by defining
+an Argument-Dependent Lookup (ADL) based customization point, ``is_onedpl_indirectly_device_accessible``. oneDPL
+also defines a public trait, ``is_indirectly_device_accessible[_v]`` to indicate whether an iterator is an
+"indirectly device accessible iterators".
 
 oneDPL queries this information at compile time to determine how to handle iterator types when they are passed to
 algorithms with a ``device_policy`` to avoid unnecessary data movement.
 
-ADL Customization Point: ``is_onedpl_device_accessible_content_iterator``
+ADL Customization Point: ``is_onedpl_indirectly_device_accessible``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A free function ``is_onedpl_device_accessible_content_iterator(IteratorT)`` may be defined, which accepts an argument
+A free function ``is_onedpl_indirectly_device_accessible(IteratorT)`` may be defined, which accepts an argument
 of type ``IteratorT`` and returns a type with the base characteristic of ``std::true_type`` if ``IteratorT`` refers to
-"device accessible content", or otherwise returns a type with the base characteristic of ``std::false_type``. The
+"indirectly device accessible", or otherwise returns a type with the base characteristic of ``std::false_type``. The
 function must be discoverable by ADL.
 
-The function ``is_onedpl_device_accessible_content_iterator`` may be used by oneDPL to determine if the iterator refers
-to "device accessible content" by interrogating its return type at compile-time only. Overloads may be provided as
+The function ``is_onedpl_indirectly_device_accessible`` may be used by oneDPL to determine if the iterator refers
+to "indirectly device accessible" by interrogating its return type at compile-time only. Overloads may be provided as
 forward declarations only, without a body defined. ADL is used to determine which function overload to use according to
 the rules in the `C++ Standard`_. Therefore, derived iterator types without an overload for their exact type will match
 their most specific base iterator type if such an overload exists.
 
-The default implementation of ``is_onedpl_device_accessible_content_iterator`` marks the following iterators as to
-"device accessible content iterators":
+The default implementation of ``is_onedpl_indirectly_device_accessible`` marks the following iterators as to
+"indirectly device accessible iterators":
 * Pointers (to handle USM pointers)
-* ``std::reverse_iterator<IteratorT>`` when ``IteratorT`` refers to "device accessible content"
+* ``std::reverse_iterator<IteratorT>`` when ``IteratorT`` refers to "indirectly device accessible"
 
 
 
-Public Trait: ``oneapi::dpl::is_device_accessible_content_iterator[_v]``
+Public Trait: ``oneapi::dpl::is_indirectly_device_accessible[_v]``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The following class template and variable template are defined in ``<oneapi/dpl/iterator>`` inside the namespace
@@ -383,13 +381,13 @@ The following class template and variable template are defined in ``<oneapi/dpl/
 .. code:: cpp
 
     template <typename T>
-    struct is_device_accessible_content_iterator{ /* see below */ };
+    struct is_indirectly_device_accessible{ /* see below */ };
 
     template <typename T>
-    inline constexpr bool is_device_accessible_content_iterator_v = is_device_accessible_content_iterator<T>::value;
+    inline constexpr bool is_indirectly_device_accessible_v = is_indirectly_device_accessible<T>::value;
 
-``template <typename T> oneapi::dpl::is_device_accessible_content_iterator`` is a type which has the base characteristic
-of ``std::true_type`` if ``T``  refers to "device accessible content", otherwise it has the base characteristic of
+``template <typename T> oneapi::dpl::is_indirectly_device_accessible`` is a type which has the base characteristic
+of ``std::true_type`` if ``T``  refers to "indirectly device accessible", otherwise it has the base characteristic of
 ``std::false_type``.
 
 
@@ -399,7 +397,7 @@ of ``std::true_type`` if ``T``  refers to "device accessible content", otherwise
 Example
 ^^^^^^^
 
-The following example shows how to define a customization for `is_device_accessible_content_iterator` trait for a simple
+The following example shows how to define a customization for `is_indirectly_device_accessible` trait for a simple
 user defined iterator.  It also shows a more complicated example where the customization is defined as a hidden friend
 of the iterator class.
 
@@ -409,24 +407,24 @@ of the iterator class.
     {
         struct accessible_it
         {
-            /* unspecified user definition of a iterator which refers to "device accessible content" */
+            /* unspecified user definition of a iterator which refers to "indirectly device accessible" */
         };
 
         std::true_type
-        is_onedpl_device_accessible_content_iterator(accessible_it);
+        is_onedpl_indirectly_device_accessible(accessible_it);
 
         struct inaccessible_it
         {
-            /* unspecified user definition of iterator which doesn't refer to "device accessible content" */
+            /* unspecified user definition of iterator which doesn't refer to "indirectly device accessible" */
         };
 
         // This could be omitted. It would rely upon the default implementation with the same result
         std::false_type
-        is_onedpl_device_accessible_content_iterator(inaccessible_it);
+        is_onedpl_indirectly_device_accessible(inaccessible_it);
     }
 
-    static_assert(oneapi::dpl::is_device_accessible_content_iterator<usr::accessible_it> == true);
-    static_assert(oneapi::dpl::is_device_accessible_content_iterator<usr::inaccessible_it> == false);
+    static_assert(oneapi::dpl::is_indirectly_device_accessible<usr::accessible_it> == true);
+    static_assert(oneapi::dpl::is_indirectly_device_accessible<usr::inaccessible_it> == false);
 
     // Example with base iterators and ADL overload as a hidden friend
     template <typename It1, typename It2>
@@ -434,13 +432,13 @@ of the iterator class.
     {
         It1 first;
         It2 second;
-        friend auto is_onedpl_device_accessible_content_iterator(it_pair) ->
-            std::conjunction<oneapi::dpl::is_device_accessible_content_iterator<It1>,
-                             oneapi::dpl::is_device_accessible_content_iterator<It2>>;
+        friend auto is_onedpl_indirectly_device_accessible(it_pair) ->
+            std::conjunction<oneapi::dpl::is_indirectly_device_accessible<It1>,
+                             oneapi::dpl::is_indirectly_device_accessible<It2>>;
     };
 
-    static_assert(oneapi::dpl::is_device_accessible_content_iterator<it_pair<usr::accessible_it, usr::accessible_it>> == true);
-    static_assert(oneapi::dpl::is_device_accessible_content_iterator<it_pair<usr::accessible_it, usr::inaccessible_it>> == false);
+    static_assert(oneapi::dpl::is_indirectly_device_accessible<it_pair<usr::accessible_it, usr::accessible_it>> == true);
+    static_assert(oneapi::dpl::is_indirectly_device_accessible<it_pair<usr::accessible_it, usr::inaccessible_it>> == false);
 
 .. _`C++ Standard`: https://isocpp.org/std/the-standard
 .. _`SYCL`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -18,7 +18,7 @@ An example of *indirectly device accessible iterators* include SYCL USM shared p
 a SYCL kernel. An example of an iterator type that is not *indirectly device accessible* is a random access iterator
 referring to host allocated data because dereferencing it within a SYCL kernel would result in undefined behavior.
 
-:doc:`*buffer position objects* <buffer_wrappers>` returned by ``oneapi::dpl::begin`` and ``oneapi::dpl::end`` are not
+:doc:`Buffer position objects <buffer_wrappers>` returned by ``oneapi::dpl::begin`` and ``oneapi::dpl::end`` are not
 iterators. However, they are *indirectly device accessible* because they represent data accessible on the device.
 
 When passed to oneDPL algorithms with a ``device_policy``, *indirectly device accessible iterator* types that are also
@@ -28,8 +28,8 @@ required by the algorithm's semantics and what would be required to use the type
 required by the algorithm's semantics and what would be required by using an accessor to the buffer within a SYCL
 kernel.
 
-Indirect Device Accessibility Trait
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Indirect Device Accessibility Type Trait
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The following class template and variable template are defined in ``<oneapi/dpl/iterator>`` inside the namespace
 ``oneapi::dpl``:
@@ -434,8 +434,10 @@ of the iterator class.
                              oneapi::dpl::is_indirectly_device_accessible<It2>>;
     };
 
-    static_assert(oneapi::dpl::is_indirectly_device_accessible<it_pair<usr::accessible_it, usr::accessible_it>> == true);
-    static_assert(oneapi::dpl::is_indirectly_device_accessible<it_pair<usr::accessible_it, usr::inaccessible_it>> == false);
+    static_assert(oneapi::dpl::is_indirectly_device_accessible<
+                                    it_pair<usr::accessible_it, usr::accessible_it>> == true);
+    static_assert(oneapi::dpl::is_indirectly_device_accessible<
+                                    it_pair<usr::accessible_it, usr::inaccessible_it>> == false);
 
 .. _`C++ Standard`: https://isocpp.org/std/the-standard
 .. _`SYCL`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -392,7 +392,7 @@ Example
     static_assert(oneapi::dpl::is_passed_directly_to_device_v<usr::pass_dir_it> == true);
     static_assert(oneapi::dpl::is_passed_directly_to_device_v<usr::no_pass_dir_it> == false);
 
-    //Example with base iterators as a hidden friend
+    // Example with base iterators and ADL overload as a hidden friend
     template <typename It1, typename It2>
     struct it_pair
     {

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -370,7 +370,6 @@ their most specific base iterator type if such an overload exists.
 The default implementation of ``is_onedpl_device_accessible_content_iterator`` marks the following iterators as to
 "device accessible content iterators":
 * Pointers (to handle USM pointers)
-* Iterators to USM shared allocated ``std::vector``-s when the allocator type is knowable from the iterator type
 * ``std::reverse_iterator<IteratorT>`` when ``IteratorT`` refers to "device accessible content"
 
 

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -397,8 +397,8 @@ Simple Examples
     is_passed_directly_in_onedpl_device_policies(const my_non_pass_dir_iterator&);
   }
 
-    // oneapi::dpl::is_passed_directly_to_device_v<user::my_pass_dir_iterator> will evaluate to `true``
-    // oneapi::dpl::is_passed_directly_to_device_v<user::my_non_pass_dir_iterator> will evaluate to `false``
+  // oneapi::dpl::is_passed_directly_to_device_v<user::my_pass_dir_iterator> will evaluate to `true``
+  // oneapi::dpl::is_passed_directly_to_device_v<user::my_non_pass_dir_iterator> will evaluate to `false``
 
 Example with base iterators as a hidden friend
 
@@ -413,8 +413,8 @@ Example with base iterators as a hidden friend
                             oneapi::dpl::is_passed_directly_to_device<It2>>;
   };
 
-    // oneapi::dpl::is_passed_directly_to_device_v<iterator_pair<user::my_pass_dir_iterator, user::my_pass_dir_iterator>> will evaluate to `true``
-    // oneapi::dpl::is_passed_directly_to_device_v<iterator_pair<user::my_pass_dir_iterator, user::my_non_pass_dir_iterator>> will evaluate to `false``
+  // oneapi::dpl::is_passed_directly_to_device_v<iterator_pair<user::my_pass_dir_iterator, user::my_pass_dir_iterator>> will evaluate to `true``
+  // oneapi::dpl::is_passed_directly_to_device_v<iterator_pair<user::my_pass_dir_iterator, user::my_non_pass_dir_iterator>> will evaluate to `false``
 
 
 .. _`C++ Standard`: https://isocpp.org/std/the-standard

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -22,8 +22,8 @@ SYCL kernel. An example of an iterator which does not refer to "indirectly devic
 iterator, which requires the data to be copied to the device in some way prior to usage in a SYCL kernel within
 algorithms used with a ``device_policy``.
 
-When used as input or output with algorithms using a ``device_policy`` "indirectly device accessible iterators" must also
-be SYCL device-copyable, as defined by the SYCL Specification.
+When used as input or output with algorithms using a ``device_policy`` "indirectly device accessible iterators" must
+also be SYCL device-copyable, as defined by the SYCL Specification.
 
 oneDPL Iterators
 ++++++++++++++++
@@ -343,9 +343,9 @@ using the set of source iterators provided.
 Customization For User Defined Iterators
 ++++++++++++++++++++++++++++++++++++++++
 
-oneDPL provides a mechanism to indicate whether custom iterators are "indirectly device accessible iterators" by defining
-an Argument-Dependent Lookup (ADL) based customization point, ``is_onedpl_indirectly_device_accessible``. oneDPL
-also defines a public trait, ``is_indirectly_device_accessible[_v]`` to indicate whether an iterator is an
+oneDPL provides a mechanism to indicate whether custom iterators are "indirectly device accessible iterators" by
+defining an Argument-Dependent Lookup (ADL) based customization point, ``is_onedpl_indirectly_device_accessible``.
+oneDPL also defines a public trait, ``is_indirectly_device_accessible[_v]`` to indicate whether an iterator is an
 "indirectly device accessible iterators".
 
 oneDPL queries this information at compile time to determine how to handle iterator types when they are passed to

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -306,11 +306,31 @@ using the set of source iterators provided.
 
 .. _iterators-device-accessible:
 
+Iterator Compatibility with Device Policies
+-------------------------------------------
+
+The iterators described here are compatible with algorithms when using a ``device_policy``, but some additional
+considerations apply. Iterators used with algorithms using a ``device_policy`` must be SYCL device-copyable as defined
+by the `SYCL`_ Specification. oneDPL provides specializations for each iterator type of ``sycl::is_device_copyable``.
+Those rules are as follows:
+* ``counting_iterator``: Always device-copyable.
+* ``discard_iterator``: Always device-copyable.
+* ``permutation_iterator``: Device-copyable if both the source iterator and index map are device-copyable.
+* ``transform_iterator``: Device-copyable if the source iterator is device-copyable.
+* ``zip_iterator``: Device-copyable if all base iterators are device-copyable.
+
+To use algorithms with a ``device_policy`` efficiently, minimizing unnecessary data movement is very important. Toward
+this end, oneDPL provides a mechanism to define whether custom iterator types are of "device accessible content".
+
+Users may provide their own custom iterators as input to algorithms with a ``device_policy``, but they must ensure that
+the iterators are ``sycl::is_device_copyable``, and should also ensure that the iterators are
+of "device accessible content" if they are to be used efficiently.
+
 Customization Point for Iterators of Device Accessible Content
---------------------------------------------------------------
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 Iterator are, by default, not assumed to refer to content which is accessible on the device which requires the content
-to be copied to the device prior to being used inside a `SYCL`_ kernel. We say that iterators are of "device accessible
+to be copied to the device prior to being used inside a SYCL kernel. We say that iterators are of "device accessible
 content" when they can inherently be dereferenced on the device in a SYCL kernel. When using algorithms with a 
 ``device_policy``, iterators of "device accessible content" avoid unnecessary data movement when provided as input or
 output arguments.
@@ -328,7 +348,7 @@ achieved using the ``is_onedpl_device_accessible_content_iterator`` Argument-Dep
 and the public trait ``is_device_accessible_content_iterator[_v]``.
 
 ADL Customization Point: ``is_onedpl_device_accessible_content_iterator``
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A free function ``is_onedpl_device_accessible_content_iterator(IteratorT)`` may be defined, which accepts an argument
 of type ``IteratorT`` and returns a type with the characteristics of ``std::true_type`` if ``IteratorT`` refers to
@@ -361,7 +381,7 @@ content".
 
 
 Public Trait: ``oneapi::dpl::is_device_accessible_content_iterator[_v]``
-++++++++++++++++++++++++++++++++++++++++++++++++++
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The public trait ``oneapi::dpl::is_device_accessible_content_iterator[_v]`` can be used to query whether an iterator
 refers to "device accessible content". The trait is defined in ``<oneapi/dpl/iterator>``.
@@ -374,7 +394,10 @@ characteristics of ``std::false_type``.
 refers to "device accessible content", otherwise it evaluates to ``false``.
 
 Example
-+++++++
+^^^^^^^
+The following example shows how to define a ADL overload for a simple user defined iterator.  It also shows an example
+for a more complicated case which uses a hidden friend to provide the ADL overload within the definition of the
+iterator.
 
 .. code:: cpp
 
@@ -393,6 +416,7 @@ Example
             /* unspecified user definition of iterator which doesn't refer to "device accessible content" */
         };
 
+        // This could be omitted. It would rely upon the default implementation with the same result
         std::false_type
         is_onedpl_device_accessible_content_iterator(inaccessible_it);
     }

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -216,7 +216,6 @@ The type ``IndexMap`` must be one of the following:
 * A functor with a signature equivalent to ``T operator()(const T&) const`` where ``T`` is a
   ``std::iterator_traits<SourceIterator>::difference_type``
 
-
 ``permutation_iterator::operator*`` uses the counter value of the instance on which
 it is invoked to index into the index map. The corresponding value in the map is then used
 to index into the value set defined by the source iterator. The resulting lvalue is returned

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -386,7 +386,7 @@ Simple Examples
     };
 
     std::true_type
-    is_passed_directly_in_onedpl_device_policies(const my_pass_dir_iterator&);
+    is_passed_directly_in_onedpl_device_policies(my_pass_dir_iterator);
 
     struct my_non_pass_dir_iterator
     {
@@ -394,7 +394,7 @@ Simple Examples
     };
 
     std::false_type
-    is_passed_directly_in_onedpl_device_policies(const my_non_pass_dir_iterator&);
+    is_passed_directly_in_onedpl_device_policies(my_non_pass_dir_iterator);
   }
 
   // oneapi::dpl::is_passed_directly_to_device_v<user::my_pass_dir_iterator> will evaluate to `true``
@@ -408,7 +408,7 @@ Example with base iterators as a hidden friend
   {
     It1 first;
     It2 second;
-    friend auto is_passed_directly_in_onedpl_device_policies(const iterator_pair&) ->
+    friend auto is_passed_directly_in_onedpl_device_policies(iterator_pair) ->
         std::conjunction<oneapi::dpl::is_passed_directly_to_device<It1>,
                             oneapi::dpl::is_passed_directly_to_device<It2>>;
   };

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -28,8 +28,8 @@ required by the algorithm's semantics and what would be required to use the type
 required by the algorithm's semantics and what would be required by using an accessor to the buffer within a SYCL
 kernel.
 
-Public Trait: ``oneapi::dpl::is_indirectly_device_accessible[_v]``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Indirect Device Accessibility Trait
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The following class template and variable template are defined in ``<oneapi/dpl/iterator>`` inside the namespace
 ``oneapi::dpl``:

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -378,24 +378,24 @@ Simple Examples
 
 .. code:: cpp
 
-  namespace user
-  {
-    struct my_pass_dir_iterator
+    namespace user
     {
-      /* unspecified user definition of a "passed directly" iterator */
-    };
+        struct my_pass_dir_iterator
+        {
+        /* unspecified user definition of a "passed directly" iterator */
+        };
 
-    std::true_type
-    is_passed_directly_in_onedpl_device_policies(my_pass_dir_iterator);
+        std::true_type
+        is_passed_directly_in_onedpl_device_policies(my_pass_dir_iterator);
 
-    struct my_non_pass_dir_iterator
-    {
-        /* unspecified user definition of a non "passed directly" iterator */
-    };
+        struct my_non_pass_dir_iterator
+        {
+            /* unspecified user definition of a non "passed directly" iterator */
+        };
 
-    std::false_type
-    is_passed_directly_in_onedpl_device_policies(my_non_pass_dir_iterator);
-  }
+        std::false_type
+        is_passed_directly_in_onedpl_device_policies(my_non_pass_dir_iterator);
+    }
 
   // oneapi::dpl::is_passed_directly_to_device_v<user::my_pass_dir_iterator> will evaluate to `true``
   // oneapi::dpl::is_passed_directly_to_device_v<user::my_non_pass_dir_iterator> will evaluate to `false``
@@ -403,15 +403,16 @@ Simple Examples
 Example with base iterators as a hidden friend
 
 .. code:: cpp
-  template <typename It1, typename It2>
-  struct iterator_pair
-  {
-    It1 first;
-    It2 second;
-    friend auto is_passed_directly_in_onedpl_device_policies(iterator_pair) ->
-        std::conjunction<oneapi::dpl::is_passed_directly_to_device<It1>,
-                            oneapi::dpl::is_passed_directly_to_device<It2>>;
-  };
+
+    template <typename It1, typename It2>
+    struct iterator_pair
+    {
+        It1 first;
+        It2 second;
+        friend auto is_passed_directly_in_onedpl_device_policies(iterator_pair) ->
+            std::conjunction<oneapi::dpl::is_passed_directly_to_device<It1>,
+                             oneapi::dpl::is_passed_directly_to_device<It2>>;
+    };
 
   // oneapi::dpl::is_passed_directly_to_device_v<iterator_pair<user::my_pass_dir_iterator, user::my_pass_dir_iterator>> will evaluate to `true``
   // oneapi::dpl::is_passed_directly_to_device_v<iterator_pair<user::my_pass_dir_iterator, user::my_non_pass_dir_iterator>> will evaluate to `false``

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -346,8 +346,8 @@ Customization For User Defined Iterators
 ++++++++++++++++++++++++++++++++++++++++
 
 oneDPL provides a mechanism to indicate whether custom iterators are "device accessible content iterators" by defining
-an Argument-Dependent Lookup (ADL) customization point, ``is_onedpl_device_accessible_content_iterator``. oneDPL also
-defines a public trait, ``is_device_accessible_content_iterator[_v]`` to indicate whether an iterator is a "device
+an Argument-Dependent Lookup (ADL) based customization point, ``is_onedpl_device_accessible_content_iterator``. oneDPL
+also defines a public trait, ``is_device_accessible_content_iterator[_v]`` to indicate whether an iterator is a "device
 accessible content iterator".
 
 oneDPL queries this information at compile time to determine how to handle iterator types when they are passed to
@@ -358,16 +358,14 @@ ADL Customization Point: ``is_onedpl_device_accessible_content_iterator``
 
 A free function ``is_onedpl_device_accessible_content_iterator(IteratorT)`` may be defined, which accepts an argument
 of type ``IteratorT`` and returns a type with the characteristics of ``std::true_type`` if ``IteratorT`` refers to
-"device accessible content", or alternatively returns a type with the characteristics of ``std::false_type``
-otherwise. The function must be defined in one of the valid search locations for ADL lookup, which includes the
-namespace of the definition of the iterator type ``IteratorT``.
+"device accessible content", or otherwise returns a type with the characteristics of ``std::false_type``. The function
+must be discoverable by ADL.
 
 The function ``is_onedpl_device_accessible_content_iterator`` may be used by oneDPL to determine if the iterator refers
-to "device accessible content" by interrogating its return type at compile-time only. It shall not be called by oneDPL
-outside a ``decltype`` context to determine the return type. Overloads may be provided as forward declarations only,
-without a body defined. ADL lookup is used to determine which function overload to use according to the rules in the
-`C++ Standard`_. Therefore, derived iterator types without an overload for their exact type will match their most
-specific base iterator type if such an overload exists.
+to "device accessible content" by interrogating its return type at compile-time only. Overloads may be provided as
+forward declarations only, without a body defined. ADL is used to determine which function overload to use according to
+the rules in the `C++ Standard`_. Therefore, derived iterator types without an overload for their exact type will match
+their most specific base iterator type if such an overload exists.
 
 The default implementation of ``is_onedpl_device_accessible_content_iterator`` marks the following iterators as to
 "device accessible content iterators":
@@ -380,15 +378,21 @@ The default implementation of ``is_onedpl_device_accessible_content_iterator`` m
 Public Trait: ``oneapi::dpl::is_device_accessible_content_iterator[_v]``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The public trait ``oneapi::dpl::is_device_accessible_content_iterator[_v]`` can be used to query whether an iterator
-is a "device accessible content iterator". The trait is defined in ``<oneapi/dpl/iterator>``.
+The following class template and variable template are defined in ``<oneapi/dpl/iterator>`` inside the namespace
+``oneapi::dpl``:
+
+.. code:: cpp
+    template <typename T>
+    struct is_device_accessible_content_iterator;
+
+    template <typename T>
+    inline constexpr bool is_device_accessible_content_iterator_v =
+        is_device_accessible_content_iterator<T>::value;
 
 ``oneapi::dpl::is_device_accessible_content_iterator<T>`` evaluates to a type with the characteristics of
 ``std::true_type`` if ``T``  refers to "device accessible content", otherwise it evaluates to a type with the
 characteristics of ``std::false_type``.
 
-``oneapi::dpl::is_device_accessible_content_iterator<T>`` is a ``constexpr bool`` that evaluates to ``true`` if ``T``
-refers to "device accessible content", otherwise it evaluates to ``false``.
 
 
 
@@ -396,9 +400,9 @@ refers to "device accessible content", otherwise it evaluates to ``false``.
 Example
 ^^^^^^^
 
-The following example shows how to define a ADL overload for a simple user defined iterator.  It also shows an example
-for a more complicated case which uses a hidden friend to provide the ADL overload within the definition of the
-iterator.
+The following example shows how to define a customization for `is_device_accessible_content_iterator` trait for a simple
+user defined iterator.  It also shows a more complicated example where the customization is defined as a hidden friend
+of the iterator class.
 
 .. code:: cpp
 

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -371,6 +371,10 @@ of ``std::reverse_iterator``.
 Pointers are assumed to be USM shared or device memory pointers and are *indirectly device accessible*.
 Pointers are trivially copyable and therefore SYCL device-copyable.
 
+Whether or not ``std::vector::iterator`` are *indirectly device accessible* is implementation defined, and may depend on
+the allocator used to create the vector. The SYCL device-copyable requirement ``std::vector::iterator`` for use in
+algorithms with a ``device_policy`` relies upon the trivial copyability of the specific implementation of the iterator.
+
 .. _iterators-device-accessible:
 
 Customization For User Defined Iterators

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -316,8 +316,8 @@ iterator type that should not be "passed directly" is a ``std::vector`` iterator
 to the device in some way prior to usage in a SYCL kernel within algorithms used with a ``device_policy``.
 
 oneDPL provides a mechanism to define whether custom iterator types should be "passed directly" to SYCL kernels.
-This is achieved using the ``is_passed_directly_in_onedpl_device_policies`` Argument-Dependent Lookup (ADL) customization
-point and the public trait ``is_passed_directly_to_device[_v]``.
+This is achieved using the ``is_passed_directly_in_onedpl_device_policies`` Argument-Dependent Lookup (ADL) 
+customization point and the public trait ``is_passed_directly_to_device[_v]``.
 
 ADL Customization Point: ``is_passed_directly_in_onedpl_device_policies``
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -332,8 +332,8 @@ The function ``is_passed_directly_in_onedpl_device_policies`` is used by oneDPL 
 should be "passed directly" to SYCL kernels by interrogating its return type at compile time only. It shall not be
 called by oneDPL outside a ``decltype`` context to determine the return type. This means that overloads may be provided
 as forward declarations only, without a body defined. ADL lookup is used to determine which function overload to use
-according to the rules in the C++ Standard. Therefore, derived iterator types without an overload for their exact type
-will match their most specific base iterator type if such an overload exists.
+according to the rules in the `C++ Standard`_. Therefore, derived iterator types without an overload for their exact
+type will match their most specific base iterator type if such an overload exists.
 
 The default implementation of ``is_passed_directly_in_onedpl_device_policies`` marks the following iterators as
 "passed directly":

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -372,8 +372,9 @@ Pointers are assumed to be USM shared or device memory pointers and are *indirec
 Pointers are trivially copyable and therefore SYCL device-copyable.
 
 Whether or not ``std::vector::iterator`` are *indirectly device accessible* is implementation defined, and may depend on
-the allocator used to create the vector. The SYCL device-copyable requirement ``std::vector::iterator`` for use in
-algorithms with a ``device_policy`` relies upon the trivial copyability of the specific implementation of the iterator.
+the allocator used to create the vector, as well as the specific implementation of ``std::vector``. The SYCL
+device-copyable requirement ``std::vector::iterator`` for use in algorithms with a ``device_policy`` relies upon the
+trivial copyability of the specific implementation ``std::vector``.
 
 .. _iterators-device-accessible:
 

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -357,9 +357,9 @@ ADL Customization Point: ``is_onedpl_device_accessible_content_iterator``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A free function ``is_onedpl_device_accessible_content_iterator(IteratorT)`` may be defined, which accepts an argument
-of type ``IteratorT`` and returns a type with the characteristics of ``std::true_type`` if ``IteratorT`` refers to
-"device accessible content", or otherwise returns a type with the characteristics of ``std::false_type``. The function
-must be discoverable by ADL.
+of type ``IteratorT`` and returns a type with the base characteristic of ``std::true_type`` if ``IteratorT`` refers to
+"device accessible content", or otherwise returns a type with the base characteristic of ``std::false_type``. The
+function must be discoverable by ADL.
 
 The function ``is_onedpl_device_accessible_content_iterator`` may be used by oneDPL to determine if the iterator refers
 to "device accessible content" by interrogating its return type at compile-time only. Overloads may be provided as
@@ -388,9 +388,9 @@ The following class template and variable template are defined in ``<oneapi/dpl/
     template <typename T>
     inline constexpr bool is_device_accessible_content_iterator_v = is_device_accessible_content_iterator<T>::value;
 
-``template <typename T> oneapi::dpl::is_device_accessible_content_iterator<T>`` evaluates to a type with the 
-characteristics of ``std::true_type`` if ``T``  refers to "device accessible content", otherwise it evaluates to a type
-with the characteristics of ``std::false_type``.
+``template <typename T> oneapi::dpl::is_device_accessible_content_iterator`` is a type which has the base characteristic
+of ``std::true_type`` if ``T``  refers to "device accessible content", otherwise it has the base characteristic of
+``std::false_type``.
 
 
 
@@ -409,7 +409,7 @@ of the iterator class.
     {
         struct accessible_it
         {
-        /* unspecified user definition of a iterator which refers to "device accessible content" */
+            /* unspecified user definition of a iterator which refers to "device accessible content" */
         };
 
         std::true_type

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -14,10 +14,9 @@ Iterators and iterator-like types may or may not refer to content accessible wit
 The term *indirectly device accessible* refers to a type that represents content accessible on a device.
 An *indirectly device accessible iterator* is such a type that can also be dereferenced within a SYCL kernel.
 
-Examples of *indirectly device accessible iterators* include SYCL USM shared or device memory pointers, as well as
-iterator types like ``counting_iterator`` or ``discard_iterator``, which can inherently be used in a SYCL kernel. An
-example of an iterator type that is not *indirectly device accessible* is a ``std::vector`` iterator with a host
-allocator, as it cannot inherently be used in a SYCL kernel.
+An example of *indirectly device accessible iterators* include SYCL USM shared pointers which can inherently be used in
+a SYCL kernel. An example of an iterator type that is not *indirectly device accessible* is a ``std::vector`` iterator
+with a host allocator because dereferencing it within a SYCL kernel would result in undefined behavior.
 
 :doc:`*buffer position objects* <buffer_wrappers>` returned by ``oneapi::dpl::begin`` and ``oneapi::dpl::end`` are not
 iterators. However, they are *indirectly device accessible* because they represent data accessible on the device.

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -338,6 +338,17 @@ is an "indirectly device accessible iterator" if all the source iterators are "i
 ``make_zip_iterator`` constructs and returns an instance of ``zip_iterator``
 using the set of source iterators provided.
 
+Other Supported Iterators
++++++++++++++++++++++++++
+``std::reverse_iterator<IteratorT>`` is an ``AdaptingIteratorSource`` if ``IteratorT`` is an ``AdaptingIteratorSource``.
+``std::reverse_iterator<IteratorT>`` is an "indirectly device accessible iterator" if ``IteratorT`` is an "indirectly
+device accessible iterator". The SYCL device-copyable requirement of ``std::reverse_iterator<IteratorT>`` for use in
+algorithms with a ``device_policy`` relies upon the trivial copyability of ``IteratorT`` and the specific implementation
+of ``std::reverse_iterator``. oneDPL does not specialize ``sycl::is_device_copyable`` for ``std::reverse_iterator``.
+
+Pointers are assumed to be USM shared or device memory pointers and are "indirectly device accessible iterators".
+Pointers are trivially copyable and therefore SYCL device-copyable.
+
 .. _iterators-device-accessible:
 
 Customization For User Defined Iterators
@@ -365,12 +376,11 @@ forward declarations only, without a body defined. ADL is used to determine whic
 the rules in the `C++ Standard`_. Therefore, derived iterator types without an overload for their exact type will match
 their most specific base iterator type if such an overload exists.
 
-The default implementation of ``is_onedpl_indirectly_device_accessible`` marks the following iterators as to
-"indirectly device accessible iterators":
+If no other overload is found, the default implementation of ``is_onedpl_indirectly_device_accessible`` is used.
+The default implementation of ``is_onedpl_indirectly_device_accessible`` returns ``std::true_type`` for the following
+iterator types, and ``std::false_type`` for all other iterator types:
 * Pointers (to handle USM pointers)
-* ``std::reverse_iterator<IteratorT>`` when ``IteratorT`` refers to "indirectly device accessible"
-
-
+* ``std::reverse_iterator<IteratorT>`` where ``IteratorT`` is an "indirectly device accessible iterator"
 
 Public Trait: ``oneapi::dpl::is_indirectly_device_accessible[_v]``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -10,23 +10,24 @@ Iterators
 
 Requirements For Iterator Use With Device Policies
 ++++++++++++++++++++++++++++++++++++++++++++++++++
-Iterators and iterator-like types may or may not refer to device accessible content. The term *indirectly device
-accessible* describes a type representing content that is accessible on the device within a `SYCL`_ kernel. *Indirectly
+Iterators and iterator-like types may or may not refer to content accessible on the device. The term *indirectly device
+accessible* refers to a type that represents content accessible on the device within a `SYCL`_ kernel. *Indirectly
 device accessible iterators* are iterators that can inherently be dereferenced on the device within a SYCL kernel.
 
-Examples of *indirectly device accessible iterators* include SYCL USM shared or device memory, or iterator types like
-``counting_iterator`` or ``discard_iterator`` that can be used inherently in a SYCL kernel. An example of an iterator
-type that is not *indirectly device accessible* is a ``std::vector`` iterator with a host allocator, which cannot be
-used inherently in a SYCL kernel.
+Examples of *indirectly device accessible iterators* include SYCL USM shared or device memory pointers, as well as
+iterator types like ``counting_iterator`` or ``discard_iterator``, which can inherently be used in a SYCL kernel. An
+example of an iterator type that is not *indirectly device accessible* is a ``std::vector`` iterator with a host
+allocator, as it cannot inherently be used in a SYCL kernel.
 
 :doc:`*buffer position objects* <buffer_wrappers>` returned by ``oneapi::dpl::begin`` and ``oneapi::dpl::end`` are not
-iterators, but they are *indirectly device accessible* because they represent data that is accessible on the device.
+iterators. However, they are *indirectly device accessible* because they represent data accessible on the device.
 
-When passed to oneDPL algorithms with a ``device_policy``, *indirectly device accessible iterator* types which are also
-random access iterators and satisfy *SYCL device-copyable* must not result in data movement beyond what is required by
-the semantics of the algorithm and what would be required to use the type directly within a SYCL kernel. *indirectly
-device accessible* *buffer position objects* must not result in data movement beyond what is required by the semantics
-of the algorithm and what would be required by using an accessor to the buffer within a SYCL kernel.
+When passed to oneDPL algorithms with a ``device_policy``, *indirectly device accessible iterator* types that are also
+random access iterators and satisfy *SYCL device-copyable* must not cause unnecessary data movement beyond what is
+required by the algorithm's semantics and what would be required to use the type directly within a SYCL kernel.
+*Indirectly device accessible* *buffer position objects* must not cause unnecessary data movement beyond what is
+required by the algorithm's semantics and what would be required by using an accessor to the buffer within a SYCL
+kernel.
 
 Public Trait: ``oneapi::dpl::is_indirectly_device_accessible[_v]``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -389,14 +390,14 @@ otherwise returns a type with the base characteristic of ``std::false_type``. Th
 
 The function ``is_onedpl_indirectly_device_accessible(T)`` may only be used to determine if ``T`` is *indirectly device
 accessible* by interrogating its return type at compile-time. Overloads may be provided as forward declarations only,
-without a body defined. ADL is used to determine which function overload to use according to the rules in the
+without defining a body. ADL is used to determine which function overload to use according to the rules in the
 `C++ Standard`_. Therefore, derived iterator types without an overload for their exact type will match their most
 specific base iterator type if such an overload exists.
 
 Once ``is_onedpl_indirectly_device_accessible(T)`` is defined, the public trait
-``template<typename T> oneapi::dpl::is_indirectly_device_accessible[_v]`` will report the appropriate value. The public
-trait may be used to define the return type of ``is_onedpl_indirectly_device_accessible(T)`` by applying it to any 
-source iterator component types. See the example below.
+``template<typename T> oneapi::dpl::is_indirectly_device_accessible[_v]`` will return the appropriate value. This public
+trait can also be used to define the return type of ``is_onedpl_indirectly_device_accessible(T)`` by applying it to any 
+source iterator component types. Refer to the example below.
 
 Example
 ^^^^^^^

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -309,7 +309,7 @@ using the set of source iterators provided.
 Customization Point for "Passed Directly" Iterators
 ---------------------------------------------------
 
-Iterator types can be "passed directly" to SYCL kernels when they can inherently be dereferenced on the device while
+Iterator types can be "passed directly" to `SYCL`_ kernels when they can inherently be dereferenced on the device while
 using an algorithm with a ``device_policy``. Examples of iterators which can be "passed directly" include SYCL USM
 shared or device memory, or iterator types like ``counting_iterator`` or ``discard_iterator`` that do not require any
 data to be copied to the device. An example of an iterator type that cannot be "passed directly" is a ``std::vector``
@@ -408,3 +408,4 @@ Example
 
 
 .. _`C++ Standard`: https://isocpp.org/std/the-standard
+.. _`SYCL`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -309,13 +309,13 @@ using the set of source iterators provided.
 Customization Point for "Passed Directly" Iterators
 ---------------------------------------------------
 
-Iterator types should be "passed directly" to SYCL kernels when they are inherently accessible on the device while using
-an algorithm with a ``device_policy``. Examples include SYCL USM shared or device memory, or iterator types like
+Iterator types can be "passed directly" to SYCL kernels when they can inherently be dereferenced on the device while
+using an algorithm with a ``device_policy``. Examples include SYCL USM shared or device memory, or iterator types like
 ``counting_iterator`` or ``discard_iterator`` that do not require any data to be copied to the device. An example of an
-iterator type that should not be "passed directly" is a ``std::vector`` iterator, which requires the data to be copied
-to the device in some way prior to usage in a SYCL kernel within algorithms used with a ``device_policy``.
+iterator type that cannot be "passed directly" is a ``std::vector`` iterator, which requires the data to be copied to
+the device in some way prior to usage in a SYCL kernel within algorithms used with a ``device_policy``.
 
-oneDPL provides a mechanism to define whether custom iterator types should be "passed directly" to SYCL kernels.
+oneDPL provides a mechanism to define whether custom iterator types can be "passed directly" to SYCL kernels.
 This is achieved using the ``is_passed_directly_in_onedpl_device_policies`` Argument-Dependent Lookup (ADL) 
 customization point and the public trait ``is_passed_directly_to_device[_v]``.
 
@@ -323,13 +323,13 @@ ADL Customization Point: ``is_passed_directly_in_onedpl_device_policies``
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 A free function ``is_passed_directly_in_onedpl_device_policies(IteratorT)`` may be defined, which accepts an argument
-of type ``IteratorT`` and returns a type with the characteristics of ``std::true_type`` if ``IteratorT`` should be
+of type ``IteratorT`` and returns a type with the characteristics of ``std::true_type`` if ``IteratorT`` can be
 "passed directly" to SYCL kernels, or alternatively returns a type with the characteristics of ``std::false_type``
 otherwise. The function must be defined in one of the valid search locations for ADL lookup, which includes the
 namespace of the definition of the iterator type ``IteratorT``.
 
 The function ``is_passed_directly_in_onedpl_device_policies`` is used by oneDPL to determine whether the iterator type
-should be "passed directly" to SYCL kernels by interrogating its return type at compile time only. It shall not be
+can be "passed directly" to SYCL kernels by interrogating its return type at compile time only. It shall not be
 called by oneDPL outside a ``decltype`` context to determine the return type. This means that overloads may be provided
 as forward declarations only, without a body defined. ADL lookup is used to determine which function overload to use
 according to the rules in the `C++ Standard`_. Therefore, derived iterator types without an overload for their exact
@@ -349,11 +349,21 @@ oneDPL defines the "passed directly" behavior for its custom iterators as follow
 * ``zip_iterator``: "Passed directly" if all base iterators are "passed directly".
 
 
-Public Trait: ``is_passed_directly_to_device``
+Public Trait: ``is_passed_directly_to_device[_v]``
 ++++++++++++++++++++++++++++++++++++++++++++++
 
-The public trait ``oneapi::dpl::is_passed_directly_to_device`` can be used to query whether an iterator type is
-"passed directly". It is defined as follows:
+The public trait ``oneapi::dpl::is_passed_directly_to_device[_v]`` can be used to query whether an iterator type is
+"passed directly." The trait is defined in ``<oneapi/dpl/iterator>``, and it determines whether the iterator type
+can inherently be dereferenced on the device or "passed directly" to SYCL kernels.
+
+``oneapi::dpl::is_passed_directly_to_device<T>`` evaluates to a type with the characteristics of
+``std::true_type`` if ``T`` can be "passed directly" to SYCL kernels, otherwise it evaluates to a type with the
+characteristics of ``std::false_type``.
+
+``oneapi::dpl::is_passed_directly_to_device_v<T>`` is a variable template that evaluates to
+``true`` if ``T`` can be "passed directly" to SYCL kernels, otherwise it evaluates to ``false``.
+
+It is defined as follows:
 
 .. code:: cpp
 

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -15,8 +15,8 @@ The term *indirectly device accessible* refers to a type that represents content
 An *indirectly device accessible iterator* is such a type that can also be dereferenced within a SYCL kernel.
 
 An example of *indirectly device accessible iterators* include SYCL USM shared pointers which can inherently be used in
-a SYCL kernel. An example of an iterator type that is not *indirectly device accessible* is a ``std::vector`` iterator
-with a host allocator because dereferencing it within a SYCL kernel would result in undefined behavior.
+a SYCL kernel. An example of an iterator type that is not *indirectly device accessible* is a random access iterator
+referring to host allocated data because dereferencing it within a SYCL kernel would result in undefined behavior.
 
 :doc:`*buffer position objects* <buffer_wrappers>` returned by ``oneapi::dpl::begin`` and ``oneapi::dpl::end`` are not
 iterators. However, they are *indirectly device accessible* because they represent data accessible on the device.

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -10,9 +10,9 @@ Iterators
 
 Requirements For Iterator Use With Device Policies
 ++++++++++++++++++++++++++++++++++++++++++++++++++
-Iterators and iterator-like types may or may not refer to content accessible on the device. The term *indirectly device
-accessible* refers to a type that represents content accessible on the device within a `SYCL`_ kernel. *Indirectly
-device accessible iterators* are iterators that can inherently be dereferenced on the device within a SYCL kernel.
+Iterators and iterator-like types may or may not refer to content accessible within a `SYCL`_ kernel on a device.
+The term *indirectly device accessible* refers to a type that represents content accessible on a device.
+An *indirectly device accessible iterator* is such a type that can also be dereferenced within a SYCL kernel.
 
 Examples of *indirectly device accessible iterators* include SYCL USM shared or device memory pointers, as well as
 iterator types like ``counting_iterator`` or ``discard_iterator``, which can inherently be used in a SYCL kernel. An
@@ -384,6 +384,7 @@ Applications may define a free function ``is_onedpl_indirectly_device_accessible
 type ``T`` and returns a type with the base characteristic of ``std::true_type`` if ``T`` is *indirectly device accessible*,
 otherwise returns a type with the base characteristic of ``std::false_type``. The function must be discoverable by
 argument-dependent lookup (ADL). It may be provided as a forward declaration only, without defining a body.
+
 The return type of ``is_onedpl_indirectly_device_accessible`` is examined at compile time to determine if ``T`` is
 *indirectly device accessible*. The function overload to use must be selected with argument-dependent lookup.
 [*Note*: Therefore, according to the rules in the `C++ Standard`_, a derived type for which there is no

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -376,12 +376,6 @@ forward declarations only, without a body defined. ADL is used to determine whic
 the rules in the `C++ Standard`_. Therefore, derived iterator types without an overload for their exact type will match
 their most specific base iterator type if such an overload exists.
 
-If no other overload is found, the default implementation of ``is_onedpl_indirectly_device_accessible`` is used.
-The default implementation of ``is_onedpl_indirectly_device_accessible`` returns ``std::true_type`` for the following
-iterator types, and ``std::false_type`` for all other iterator types:
-* Pointers (to handle USM pointers)
-* ``std::reverse_iterator<IteratorT>`` where ``IteratorT`` is an "indirectly device accessible iterator"
-
 Public Trait: ``oneapi::dpl::is_indirectly_device_accessible[_v]``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -357,19 +357,19 @@ The public trait ``oneapi::dpl::is_passed_directly_to_device`` can be used to qu
 
 .. code:: cpp
 
-    namespace oneapi
-    {
-    namespace dpl
-    {
-        template <typename T>
-        struct is_passed_directly_to_device; // Evaluates to a type with the characteristics of std::true_type
-                                             // if T is "passed directly" to SYCL kernels, otherwise with the
-                                             // characteristics of std::false_type.
+  namespace oneapi
+  {
+  namespace dpl
+  {
+    template <typename T>
+    struct is_passed_directly_to_device; // Evaluates to a type with the characteristics of std::true_type
+                                            // if T is "passed directly" to SYCL kernels, otherwise with the
+                                            // characteristics of std::false_type.
 
-        template <typename T>
-        inline constexpr bool is_passed_directly_to_device_v = is_passed_directly_to_device<T>::value;
-    } // namespace dpl
-    } // namespace oneapi
+    template <typename T>
+    inline constexpr bool is_passed_directly_to_device_v = is_passed_directly_to_device<T>::value;
+  } // namespace dpl
+  } // namespace oneapi
 
 Examples
 ++++++++
@@ -377,39 +377,39 @@ Examples
 Simple Examples:
 .. code:: cpp
 
-    namespace user
+  namespace user
+  {
+    struct my_pass_dir_iterator
     {
-        struct my_pass_dir_iterator
-        {
-            /* unspecified user definition of a "passed directly" iterator */
-        };
+      /* unspecified user definition of a "passed directly" iterator */
+    };
 
-        std::true_type
-        is_passed_directly_in_onedpl_device_policies(const my_pass_dir_iterator&);
+    std::true_type
+    is_passed_directly_in_onedpl_device_policies(const my_pass_dir_iterator&);
 
-        struct my_non_pass_dir_iterator
-        {
-            /* unspecified user definition of a non "passed directly" iterator */
-        };
+    struct my_non_pass_dir_iterator
+    {
+        /* unspecified user definition of a non "passed directly" iterator */
+    };
 
-        std::false_type
-        is_passed_directly_in_onedpl_device_policies(const my_non_pass_dir_iterator&);
-    }
+    std::false_type
+    is_passed_directly_in_onedpl_device_policies(const my_non_pass_dir_iterator&);
+  }
 
     // oneapi::dpl::is_passed_directly_to_device_v<user::my_pass_dir_iterator> will evaluate to `true``
     // oneapi::dpl::is_passed_directly_to_device_v<user::my_non_pass_dir_iterator> will evaluate to `false``
 
 Example with base iterators as a hidden friend:
 .. code:: cpp
-    template <typename It1, typename It2>
-    struct iterator_pair
-    {
-        It1 first;
-        It2 second;
-        friend auto is_passed_directly_in_onedpl_device_policies(const iterator_pair&) ->
-            std::conjunction<oneapi::dpl::is_passed_directly_to_device<It1>,
-                             oneapi::dpl::is_passed_directly_to_device<It2>>;
-    };
+  template <typename It1, typename It2>
+  struct iterator_pair
+  {
+    It1 first;
+    It2 second;
+    friend auto is_passed_directly_in_onedpl_device_policies(const iterator_pair&) ->
+        std::conjunction<oneapi::dpl::is_passed_directly_to_device<It1>,
+                            oneapi::dpl::is_passed_directly_to_device<It2>>;
+  };
 
     // oneapi::dpl::is_passed_directly_to_device_v<iterator_pair<user::my_pass_dir_iterator, user::my_pass_dir_iterator>> will evaluate to `true``
     // oneapi::dpl::is_passed_directly_to_device_v<iterator_pair<user::my_pass_dir_iterator, user::my_non_pass_dir_iterator>> will evaluate to `false``

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -306,32 +306,11 @@ using the set of source iterators provided.
 
 .. _iterators-device-accessible:
 
-Iterator Compatibility with Device Policies
--------------------------------------------
-
-The iterators described here are compatible with algorithms when using a ``device_policy``, but some additional
-considerations apply. Iterators used with algorithms using a ``device_policy`` must be SYCL device-copyable as defined
-by the `SYCL`_ Specification. oneDPL provides specializations for each iterator type of ``sycl::is_device_copyable``.
-
-The rules are as follows:
-* ``counting_iterator``: Always device-copyable.
-* ``discard_iterator``: Always device-copyable.
-* ``permutation_iterator``: Device-copyable if both the source iterator and the index map are device-copyable.
-* ``transform_iterator``: Device-copyable if the source iterator is device-copyable.
-* ``zip_iterator``: Device-copyable if all base iterators are device-copyable.
-
-To use algorithms with a ``device_policy`` efficiently, minimizing unnecessary data movement is very important. To
-support this, oneDPL provides a mechanism to define whether custom iterator types are of "device accessible content."
-
-Users may provide their own custom iterators as input to algorithms with a ``device_policy``, but they must ensure that
-the iterators are ``sycl::is_device_copyable``. Additionally, for best performance, users should ensure that the
-iterators are of "device accessible content", and are marked as such using the customization point described below.
-
-Customization Point for Iterators of Device Accessible Content
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Iterators of Device Accessible Content with Device Policies
+-----------------------------------------------------------
 
 Iterator are, by default, not assumed to refer to content which is accessible on the device which requires the content
-to be copied to the device prior to being used inside a SYCL kernel. We say that iterators are of "device accessible
+to be copied to the device prior to being used inside a `SYCL`_ kernel. We say that iterators are of "device accessible
 content" when they can inherently be dereferenced on the device in a SYCL kernel. When using algorithms with a 
 ``device_policy``, iterators of "device accessible content" avoid unnecessary data movement when provided as input or
 output arguments.
@@ -349,7 +328,7 @@ achieved using the ``is_onedpl_device_accessible_content_iterator`` Argument-Dep
 and the public trait ``is_device_accessible_content_iterator[_v]``.
 
 ADL Customization Point: ``is_onedpl_device_accessible_content_iterator``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 A free function ``is_onedpl_device_accessible_content_iterator(IteratorT)`` may be defined, which accepts an argument
 of type ``IteratorT`` and returns a type with the characteristics of ``std::true_type`` if ``IteratorT`` refers to
@@ -382,7 +361,7 @@ content".
 
 
 Public Trait: ``oneapi::dpl::is_device_accessible_content_iterator[_v]``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 The public trait ``oneapi::dpl::is_device_accessible_content_iterator[_v]`` can be used to query whether an iterator
 refers to "device accessible content". The trait is defined in ``<oneapi/dpl/iterator>``.
@@ -394,8 +373,23 @@ characteristics of ``std::false_type``.
 ``oneapi::dpl::is_device_accessible_content_iterator<T>`` is a ``constexpr bool`` that evaluates to ``true`` if ``T``
 refers to "device accessible content", otherwise it evaluates to ``false``.
 
+Device Copyability of Iterators
++++++++++++++++++++++++++++++++
+
+Iterators referring to "device accessible content" used as input or output with algorithms using a ``device_policy``
+must also be SYCL device-copyable as defined by the SYCL Specification. oneDPL provides specializations for
+``sycl::is_device_copyable`` for each of its provide iterator types.
+
+The rules are as follows:
+* ``counting_iterator``: Always device-copyable.
+* ``discard_iterator``: Always device-copyable.
+* ``permutation_iterator``: Device-copyable if both the source iterator and the index map are device-copyable.
+* ``transform_iterator``: Device-copyable if the source iterator is device-copyable.
+* ``zip_iterator``: Device-copyable if all base iterators are device-copyable.
+
 Example
-^^^^^^^
++++++++
+
 The following example shows how to define a ADL overload for a simple user defined iterator.  It also shows an example
 for a more complicated case which uses a hidden friend to provide the ADL overload within the definition of the
 iterator.
@@ -438,7 +432,6 @@ iterator.
 
     static_assert(oneapi::dpl::is_device_accessible_content_iterator<it_pair<usr::accessible_it, usr::accessible_it>> == true);
     static_assert(oneapi::dpl::is_device_accessible_content_iterator<it_pair<usr::accessible_it, usr::inaccessible_it>> == false);
-
 
 .. _`C++ Standard`: https://isocpp.org/std/the-standard
 .. _`SYCL`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -309,37 +309,36 @@ using the set of source iterators provided.
 Customization Point for "Passed Directly" Iterators
 ---------------------------------------------------
 
-Iterator types should be "passed directly" to SYCL kernels when they are inherently accessible on the device when using
-an algorithm with a ``device_policy``, like in the case of SYCL USM shared or device memory, or when the iterator type
-is something like a ``counting_iterator`` or ``discard_iterator`` that does not require any data to be copied to the
-device. An example of an iterator type that should not be "passed directly" is a ``std::vector`` iterator, which
-requires the data to be copied to the device in some way prior to usage in a SYCL kernel within algorithms used with a
-``device_policy``.
+Iterator types should be "passed directly" to SYCL kernels when they are inherently accessible on the device while using
+an algorithm with a ``device_policy``. Examples include SYCL USM shared or device memory, or iterator types like
+``counting_iterator`` or ``discard_iterator`` that do not require any data to be copied to the device. An example of an
+iterator type that should not be "passed directly" is a ``std::vector`` iterator, which requires the data to be copied
+to the device in some way prior to usage in a SYCL kernel within algorithms used with a ``device_policy``.
 
 oneDPL provides a mechanism to define whether custom iterator types should be "passed directly" to SYCL kernels.
-This is achieved using the ``is_passed_directly_in_onedpl_device_policies``Argument-Dependent Lookup (ADL) customization
+This is achieved using the ``is_passed_directly_in_onedpl_device_policies`` Argument-Dependent Lookup (ADL) customization
 point and the public trait ``is_passed_directly_to_device[_v]``.
 
 ADL Customization Point: ``is_passed_directly_in_onedpl_device_policies``
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-A free function ``is_passed_directly_in_onedpl_device_policies(IteratorT)`` may be defined which accepts some argument
+A free function ``is_passed_directly_in_onedpl_device_policies(IteratorT)`` may be defined, which accepts an argument
 of type ``IteratorT`` and returns a type with the characteristics of ``std::true_type`` if ``IteratorT`` should be
-"passed directly" to the SYCL kernels, or alternatively returns a type with the characteristics of ``std::false_type``
-otherwise. The function must be defined in one of the valid search locations for the ADL lookup, which includes the
+"passed directly" to SYCL kernels, or alternatively returns a type with the characteristics of ``std::false_type``
+otherwise. The function must be defined in one of the valid search locations for ADL lookup, which includes the
 namespace of the definition of the iterator type ``IteratorT``.
 
 The function ``is_passed_directly_in_onedpl_device_policies`` is used by oneDPL to determine whether the iterator type
-should be "passed directly" to SYCL kernels by interrogating it's return type at compile time only. It shall not be
-called by oneDPL outside a ``decltype`` context to determine the return type.  This means that overloads may be provided
-as forward declaration only, without a body defined. ADL lookup is used to determine function overload to use according
-to the rules in the C++ Standard. Therefore, derived iterator types without an overload for their exact type will match
-to their most specific derived-from iterator type if such an overload exists.
+should be "passed directly" to SYCL kernels by interrogating its return type at compile time only. It shall not be
+called by oneDPL outside a ``decltype`` context to determine the return type. This means that overloads may be provided
+as forward declarations only, without a body defined. ADL lookup is used to determine which function overload to use
+according to the rules in the C++ Standard. Therefore, derived iterator types without an overload for their exact type
+will match their most specific base iterator type if such an overload exists.
 
 The default implementation of ``is_passed_directly_in_onedpl_device_policies`` marks the following iterators as
 "passed directly":
 * Pointers (to handle USM pointers)
-* Iterators with ``using is_passed_directly = std::true_type`` trait
+* Iterators with the ``using is_passed_directly = std::true_type`` trait
 * Iterators to USM shared allocated ``std::vector``-s when the allocator type is knowable from the iterator type
 * ``std::reverse_iterator<IteratorT>`` when ``IteratorT`` is "passed directly"
 
@@ -348,6 +347,7 @@ oneDPL defines the "passed directly" behavior for its custom iterators as follow
 * ``permutation_iterator``: "Passed directly" if both its source iterator and its index map are "passed directly".
 * ``transform_iterator``: "Passed directly" if its source iterator is "passed directly".
 * ``zip_iterator``: "Passed directly" if all base iterators are "passed directly".
+
 
 Public Trait: ``is_passed_directly_to_device``
 ++++++++++++++++++++++++++++++++++++++++++++++

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -366,12 +366,8 @@ Pointers are assumed to be USM shared or device memory pointers when used in com
 ``device_policy`` and are *indirectly device accessible*. Pointers are trivially copyable and therefore SYCL
 device-copyable.
 
-``std::reverse_iterator<IteratorT>`` is an ``AdaptingIteratorSource`` if ``IteratorT`` is an ``AdaptingIteratorSource``.
-``std::reverse_iterator<IteratorT>`` is an *indirectly device accessible iterator* if ``IteratorT`` is an *indirectly
-device accessible iterator*.
-
-Whether or not ``std::vector::iterator`` are *indirectly device accessible* is implementation defined, and may depend on
-the allocator used to create the vector, as well as the specific implementation of ``std::vector``.
+It is implementation defined whether other iterators are *indirectly device accessible*, including iterator types from
+the `C++ Standard`_.
 
 .. _iterators-device-accessible:
 
@@ -387,7 +383,7 @@ body.
 
 The return type of ``is_onedpl_indirectly_device_accessible`` is examined at compile time to determine if ``T`` is
 *indirectly device accessible*. The function overload to use must be selected with argument-dependent lookup.
-[*Note*: Therefore, according to the rules in the `C++ Standard`_, a derived type for which there is no
+[*Note*: Therefore, according to the rules in the C++ Standard, a derived type for which there is no
 function overload will match its most specific base type for which an overload exists. -- *end note*]
 
 Once ``is_onedpl_indirectly_device_accessible(T)`` is defined, the public trait

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -43,7 +43,7 @@ The following class template and variable template are defined in ``<oneapi/dpl/
     inline constexpr bool is_indirectly_device_accessible_v = is_indirectly_device_accessible<T>::value;
 
 ``template <typename T> oneapi::dpl::is_indirectly_device_accessible`` is a type which has the base characteristic
-of ``std::true_type`` if ``T`` is *indirectly device accessible*, otherwise it has the base characteristic of
+of ``std::true_type`` if ``T`` is *indirectly device accessible*. Otherwise, it has the base characteristic of
 ``std::false_type``.
 
 oneDPL Iterators
@@ -378,9 +378,10 @@ Customization For User Defined Iterators
 oneDPL provides a mechanism to indicate whether custom iterators are *indirectly device accessible*.
 
 Applications may define a free function ``is_onedpl_indirectly_device_accessible(T)``, which accepts an argument of
-type ``T`` and returns a type with the base characteristic of ``std::true_type`` if ``T`` is *indirectly device accessible*,
-otherwise returns a type with the base characteristic of ``std::false_type``. The function must be discoverable by
-argument-dependent lookup (ADL). It may be provided as a forward declaration only, without defining a body.
+type ``T`` and returns a type with the base characteristic of ``std::true_type`` if ``T`` is *indirectly device
+accessible*. Otherwise, it returns a type with the base characteristic of ``std::false_type``. The function must be
+discoverable by argument-dependent lookup (ADL). It may be provided as a forward declaration only, without defining a
+body.
 
 The return type of ``is_onedpl_indirectly_device_accessible`` is examined at compile time to determine if ``T`` is
 *indirectly device accessible*. The function overload to use must be selected with argument-dependent lookup.

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -349,7 +349,6 @@ their most specific base iterator type if such an overload exists.
 The default implementation of ``is_onedpl_device_accessible_content_iterator`` marks the following iterators as to
 "device accessible content iterators":
 * Pointers (to handle USM pointers)
-* Iterators with the ``using is_passed_directly = std::true_type`` trait
 * Iterators to USM shared allocated ``std::vector``-s when the allocator type is knowable from the iterator type
 * ``std::reverse_iterator<IteratorT>`` when ``IteratorT`` refers to "device accessible content"
 

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -382,11 +382,11 @@ The following class template and variable template are defined in ``<oneapi/dpl/
 
 .. code:: cpp
 
-template <typename T>
-struct is_device_accessible_content_iterator{ /* see below */ };
+    template <typename T>
+    struct is_device_accessible_content_iterator{ /* see below */ };
 
-template <typename T>
-inline constexpr bool is_device_accessible_content_iterator_v = is_device_accessible_content_iterator<T>::value;
+    template <typename T>
+    inline constexpr bool is_device_accessible_content_iterator_v = is_device_accessible_content_iterator<T>::value;
 
 ``template <typename T> oneapi::dpl::is_device_accessible_content_iterator<T>`` evaluates to a type with the 
 characteristics of ``std::true_type`` if ``T``  refers to "device accessible content", otherwise it evaluates to a type

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -374,7 +374,8 @@ The public trait ``oneapi::dpl::is_passed_directly_to_device`` can be used to qu
 Examples
 ++++++++
 
-Simple Examples:
+Simple Examples
+
 .. code:: cpp
 
   namespace user
@@ -399,7 +400,8 @@ Simple Examples:
     // oneapi::dpl::is_passed_directly_to_device_v<user::my_pass_dir_iterator> will evaluate to `true``
     // oneapi::dpl::is_passed_directly_to_device_v<user::my_non_pass_dir_iterator> will evaluate to `false``
 
-Example with base iterators as a hidden friend:
+Example with base iterators as a hidden friend
+
 .. code:: cpp
   template <typename It1, typename It2>
   struct iterator_pair

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -86,7 +86,7 @@ counter; dereference operations cannot be used to modify the counter. The arithm
 operators of ``counting_iterator`` behave as if applied to the values of Integral type
 representing the counters of the iterator instances passed to the operators.
 
-``counting_iterator`` are always SYCL device-copyable, and are always "device accessible content iterators".
+``counting_iterator`` are SYCL device-copyable, and are "device accessible content iterators".
 
 .. code:: cpp
 
@@ -128,7 +128,7 @@ lvalue that may be assigned an arbitrary value. The assignment has no effect on 
 of ``discard_iterator`` behave as if applied to integer counter values maintained by the
 iterator instances to determine their position relative to each other.
 
-``discard_iterator`` are always SYCL device-copyable, and are always "device accessible content iterators".
+``discard_iterator`` are SYCL device-copyable, and are "device accessible content iterators".
 
 .. code:: cpp
 
@@ -201,7 +201,7 @@ to index into the value set defined by the source iterator. The resulting lvalue
 as the result of the operator.
 
 ``permutation_iterator`` are SYCL device-copyable if both the ``SourceIterator`` and the ``IndexMap``
-are SYCL device-copyable, and are always "device accessible content iterators" if both the ``SourceIterator``
+are SYCL device-copyable, and are "device accessible content iterators" if both the ``SourceIterator``
 and the ``IndexMap`` are "device accessible content iterators".
 
 .. code:: cpp
@@ -265,7 +265,7 @@ source iterator itself. The template type ``Iterator`` must satisfy
 ``AdaptingIteratorSource``.
 
 ``transform_iterator`` is SYCL device-copyable if the source iterator is SYCL device-copyable, and
-is always "device accessible content iterator" if the source iterator is a "device accessible
+is "device accessible content iterator" if the source iterator is a "device accessible
 content iterator".
 
 .. code:: cpp
@@ -328,7 +328,7 @@ operation were applied to each of these iterators. The types ``T`` within the te
 ``Iterators...`` must satisfy ``AdaptingIteratorSource``.
 
 ``zip_iterator`` is SYCL device-copyable if all the source iterators are SYCL device-copyable, and
-is always "device accessible content iterator" if all the source iterators are "device accessible
+is "device accessible content iterator" if all the source iterators are "device accessible
 content iterators".
 
 .. code:: cpp

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -378,21 +378,16 @@ Pointers are trivially copyable and therefore SYCL device-copyable.
 
 Customization For User Defined Iterators
 ++++++++++++++++++++++++++++++++++++++++
-oneDPL provides a mechanism to indicate whether custom iterators are *indirectly device accessible* by defining an
-Argument-Dependent Lookup (ADL) based customization point, ``is_onedpl_indirectly_device_accessible``.
+oneDPL provides a mechanism to indicate whether custom iterators are *indirectly device accessible*.
 
-ADL-based Customization Point: ``is_onedpl_indirectly_device_accessible``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-A free function ``is_onedpl_indirectly_device_accessible(T)`` may be defined, which accepts an argument of type ``T``
-and returns a type with the base characteristic of ``std::true_type`` if ``T`` is *indirectly device accessible*, or
-otherwise returns a type with the base characteristic of ``std::false_type``. The function must be discoverable by ADL.
-
-The function ``is_onedpl_indirectly_device_accessible(T)`` may only be used to determine if ``T`` is *indirectly device
-accessible* by interrogating its return type at compile-time. Overloads may be provided as forward declarations only,
-without defining a body. ADL is used to determine which function overload to use according to the rules in the
-`C++ Standard`_. Therefore, derived iterator types without an overload for their exact type will match their most
-specific base iterator type if such an overload exists.
+Applications may define a free function ``is_onedpl_indirectly_device_accessible(T)``, which accepts an argument of
+type ``T`` and returns a type with the base characteristic of ``std::true_type`` if ``T`` is *indirectly device accessible*,
+otherwise returns a type with the base characteristic of ``std::false_type``. The function must be discoverable by
+argument-dependent lookup (ADL). It may be provided as a forward declaration only, without defining a body.
+The return type of ``is_onedpl_indirectly_device_accessible`` is examined at compile time to determine if ``T`` is
+*indirectly device accessible*. The function overload to use must be selected with argument-dependent lookup.
+[*Note*: Therefore, according to the rules in the `C++ Standard`_, a derived type for which there is no
+function overload will match its most specific base type for which an overload exists. -- *end note*]
 
 Once ``is_onedpl_indirectly_device_accessible(T)`` is defined, the public trait
 ``template<typename T> oneapi::dpl::is_indirectly_device_accessible[_v]`` will return the appropriate value. This public
@@ -412,7 +407,7 @@ of the iterator class.
     {
         struct accessible_it
         {
-            /* unspecified user definition of a *indirectly device accessible iterator" */
+            /* user definition of an indirectly device accessible iterator */
         };
 
         std::true_type
@@ -420,10 +415,10 @@ of the iterator class.
 
         struct inaccessible_it
         {
-            /* unspecified user definition of iterator  which is not "indirectly device accessible" */
+            /* user definition of an iterator which is not indirectly device accessible */
         };
 
-        // The following could be omitted. The default overload would provide the same result.
+        // The following could be omitted, as returning std::false_type matches the default behavior.
         std::false_type
         is_onedpl_indirectly_device_accessible(inaccessible_it);
     }

--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -365,14 +365,12 @@ The public trait ``oneapi::dpl::is_passed_directly_to_device[_v]`` can be used t
 ``oneapi::dpl::is_passed_directly_to_device_v<T>`` is a ``constexpr bool`` that evaluates to ``true`` if ``T`` can be
 "passed directly" to SYCL kernels, otherwise it evaluates to ``false``.
 
-Examples
-++++++++
-
-Simple Examples
+Example
++++++++
 
 .. code:: cpp
 
-    namespace user
+    namespace usr
     {
         struct pass_dir_it
         {
@@ -382,34 +380,31 @@ Simple Examples
         std::true_type
         is_passed_directly_in_onedpl_device_policies(pass_dir_it);
 
-        struct non_pass_dir_it
+        struct no_pass_dir_it
         {
             /* unspecified user definition of a non "passed directly" iterator */
         };
 
         std::false_type
-        is_passed_directly_in_onedpl_device_policies(non_pass_dir_it);
+        is_passed_directly_in_onedpl_device_policies(no_pass_dir_it);
     }
 
-  // oneapi::dpl::is_passed_directly_to_device_v<user::pass_dir_it> == true`
-  // oneapi::dpl::is_passed_directly_to_device_v<user::non_pass_dir_it> == false`
+    static_assert(oneapi::dpl::is_passed_directly_to_device_v<usr::pass_dir_it> == true);
+    static_assert(oneapi::dpl::is_passed_directly_to_device_v<usr::no_pass_dir_it> == false);
 
-Example with base iterators as a hidden friend
-
-.. code:: cpp
-
+    //Example with base iterators as a hidden friend
     template <typename It1, typename It2>
-    struct iterator_pair
+    struct it_pair
     {
         It1 first;
         It2 second;
-        friend auto is_passed_directly_in_onedpl_device_policies(iterator_pair) ->
+        friend auto is_passed_directly_in_onedpl_device_policies(it_pair) ->
             std::conjunction<oneapi::dpl::is_passed_directly_to_device<It1>,
                              oneapi::dpl::is_passed_directly_to_device<It2>>;
     };
 
-  // oneapi::dpl::is_passed_directly_to_device_v<iterator_pair<user::pass_dir_it, user::pass_dir_it>> == `true``
-  // oneapi::dpl::is_passed_directly_to_device_v<iterator_pair<user::pass_dir_it, user::non_pass_dir_it>> == `false``
+    static_assert(oneapi::dpl::is_passed_directly_to_device_v<it_pair<usr::pass_dir_it, usr::pass_dir_it>> == true);
+    static_assert(oneapi::dpl::is_passed_directly_to_device_v<it_pair<usr::pass_dir_it, usr::no_pass_dir_it>> == false);
 
 
 .. _`C++ Standard`: https://isocpp.org/std/the-standard


### PR DESCRIPTION
Specification for "indirectly device accessible iterator" customization point and public trait.  Based upon proposed [RFC].(https://github.com/uxlfoundation/oneDPL/pull/1999)