### PR TITLE
[oneDPL] Indirectly device accessible minor language adjustment

### DIFF
--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -42,7 +42,7 @@ The following class template and variable template are defined in ``<oneapi/dpl/
     template <typename T>
     inline constexpr bool is_indirectly_device_accessible_v = is_indirectly_device_accessible<T>::value;
 
-``template <typename T> oneapi::dpl::is_indirectly_device_accessible`` is a type which has the base characteristic
+``template <typename T> oneapi::dpl::is_indirectly_device_accessible`` is a template which has the base characteristic
 of ``std::true_type`` if ``T`` is indirectly device accessible. Otherwise, it has the base characteristic of
 ``std::false_type``.
 


### PR DESCRIPTION
From the suggestion [here](https://github.com/uxlfoundation/oneAPI-spec/pull/620#discussion_r2074207876), this PR adjust the language around `is_indirectly_device_accessible` slightly.

This is not a semantic change, so if there is consensus, I will not wait the 2 weeks to merge this.