### PR TITLE
[oneDPL] indirectly_device_accessible adjust hidden friend example 

### DIFF
--- a/source/elements/oneDPL/source/parallel_api/iterators.rst
+++ b/source/elements/oneDPL/source/parallel_api/iterators.rst
@@ -429,9 +429,13 @@ of the iterator class.
     {
         It1 first;
         It2 second;
-        friend auto is_onedpl_indirectly_device_accessible(it_pair) ->
+        friend auto
+        is_onedpl_indirectly_device_accessible(it_pair) ->
             std::conjunction<oneapi::dpl::is_indirectly_device_accessible<It1>,
-                             oneapi::dpl::is_indirectly_device_accessible<It2>>;
+                             oneapi::dpl::is_indirectly_device_accessible<It2>>
+        {
+            return {};
+        }
     };
 
     static_assert(oneapi::dpl::is_indirectly_device_accessible<


### PR DESCRIPTION
A body-less hidden friend can look like a common error for friend functions where one intends to externally define the friend, but omits a forward declaration of a template function and template syntax within the class.  

There is no actual problem with the body-less hidden friend, but to avoid looking like this common trap, lets define a minimal body in this case (which creates a one-to-one mapping with the instances of the template class).

This doesn't change the semantics, only our examples and therefore recommendations for usage.

(g++ warns when it sees something like the example prior to this change)