### PR TITLE
[oneMath][Vector Math] fix typo in Mathematical Functions docs

### DIFF
--- a/source/elements/oneMath/source/domains/vm/acospi.rst
+++ b/source/elements/oneMath/source/domains/vm/acospi.rst
@@ -114,7 +114,7 @@ acospi
          * - +∞
            - QNAN
            - ``oneapi::math::vm::status::errdom``
-         * - - ∞
+         * - -∞
            - QNAN
            - ``oneapi::math::vm::status::errdom``
          * - QNAN

--- a/source/elements/oneMath/source/domains/vm/atanh.rst
+++ b/source/elements/oneMath/source/domains/vm/atanh.rst
@@ -110,7 +110,7 @@ atanh
            - QNAN
            - ``oneapi::math::vm::status::errdom``
          * - +∞
-           - +∞
+           - QNAN
            - ``oneapi::math::vm::status::errdom``
          * - QNAN
            - QNAN

--- a/source/elements/oneMath/source/domains/vm/cbrt.rst
+++ b/source/elements/oneMath/source/domains/vm/cbrt.rst
@@ -80,7 +80,7 @@ cbrt
       :class: sectiontitle
 
 
-   The cbrt(a)function computes a cube root of vector elements.
+   The `cbrt(a)` function computes a cube root of vector elements.
 
 
    .. container:: tablenoborder
@@ -109,9 +109,6 @@ cbrt
            -  
          * - SNAN
            - QNAN
-           -  
-         * - +0
-           - +0
            -  
 
 

--- a/source/elements/oneMath/source/domains/vm/expm1.rst
+++ b/source/elements/oneMath/source/domains/vm/expm1.rst
@@ -97,10 +97,10 @@ expm1
            - Result
            - Status code
          * - +0
-           - +1
+           - +0
            -  
          * - -0
-           - +1
+           - -0
            -  
          * - a > overflow
            - +∞
@@ -109,7 +109,7 @@ expm1
            - +∞
            -  
          * - -∞
-           - -0
+           - -1
            -  
          * - QNAN
            - QNAN

--- a/source/elements/oneMath/source/domains/vm/tanpi.rst
+++ b/source/elements/oneMath/source/domains/vm/tanpi.rst
@@ -100,7 +100,7 @@ tanpi
            - +0
            -  
          * - -0
-           - +0
+           - -0
            -  
          * - ``n``, even integer
            - \*copysign(0.0, ``n``)


### PR DESCRIPTION
ref: [Std C23 Annex F: IEC 60559 floating-point arithmetic (PDF)](https://open-std.org/jtc1/sc22/wg14/www/docs/n3220.pdf)

current doc:
- [cbrt — oneAPI Specification 1.4-provisional-rev-1 documentation](https://oneapi-spec.uxlfoundation.org/specifications/oneapi/v1.4-rev-1/elements/onemath/source/domains/vm/cbrt#onemath-vm-cbrt)
- [acospi — oneAPI Specification 1.4-provisional-rev-1 documentation](https://oneapi-spec.uxlfoundation.org/specifications/oneapi/v1.4-rev-1/elements/onemath/source/domains/vm/acospi#onemath-vm-acospi)
- [atanh — oneAPI Specification 1.4-provisional-rev-1 documentation](https://oneapi-spec.uxlfoundation.org/specifications/oneapi/v1.4-rev-1/elements/onemath/source/domains/vm/atanh#onemath-vm-atanh)
- [expm1 — oneAPI Specification 1.4-provisional-rev-1 documentation](https://oneapi-spec.uxlfoundation.org/specifications/oneapi/v1.4-rev-1/elements/onemath/source/domains/vm/expm1#onemath-vm-expm1)
- [tanpi — oneAPI Specification 1.4-provisional-rev-1 documentation](https://oneapi-spec.uxlfoundation.org/specifications/oneapi/v1.4-rev-1/elements/onemath/source/domains/vm/tanpi#onemath-vm-tanpi)


`Signed-off-by: Chengyu HAN <cyhan.dev@outlook.com>`
