### PR TITLE
[oneDPL] Add more copying mutating parallel range algorithms

### DIFF
--- a/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
+++ b/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
@@ -17,7 +17,7 @@ defined by the C++ standard in ``namespace std::ranges``, they cannot be found b
 and cannot be called with explicitly specified template arguments. [*Note*: A typical implementation uses
 predefined function objects which static function call operators have the required signatures. -- *end note*]
 
-The following differences to the standard C++ serial range algorithms apply:
+The following differences to the standard C++ range algorithms apply:
 
 - Parallel range algorithms cannot be used in constant expressions.
 - The oneDPL execution policy parameter is added.
@@ -32,6 +32,7 @@ The following differences to the standard C++ serial range algorithms apply:
 - For algorithms with bounded output ranges, processing may not need to go over all the input data.
   In that case, the returned value contains iterators pointing to the positions past the last elements
   processed according to the algorithm semantics.
+- ``for_each`` does not return its function object.
 - The return type of ``reverse_copy`` is ``std::ranges::in_in_out_result``
   rather than ``std::ranges::reverse_copy_result``.
   The semantics of the returned value are as specified in

--- a/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
+++ b/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
@@ -35,7 +35,7 @@ The following differences to the standard C++ range algorithms apply:
 - ``for_each`` does not return its function object.
 - ``reverse_copy`` returns ``std::ranges::in_in_out_result`` rather than its alias,
   ``std::ranges::reverse_copy_truncated_result``, which is proposed for C++26 in
-  [P3709R2](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3709r2.html).
+  `P3709R2 <https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3709r2.html>`_.
 
 Except for these differences, the signatures of parallel range algorithms correspond to the working draft
 of the next edition of the C++ standard (C++26).

--- a/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
+++ b/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
@@ -17,7 +17,7 @@ defined by the C++ standard in ``namespace std::ranges``, they cannot be found b
 and cannot be called with explicitly specified template arguments. [*Note*: A typical implementation uses
 predefined function objects which static function call operators have the required signatures. -- *end note*]
 
-The following differences to the standard C++ range algorithms apply:
+The following differences to the standard C++ serial range algorithms apply:
 
 - Parallel range algorithms cannot be used in constant expressions.
 - The oneDPL execution policy parameter is added.

--- a/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
+++ b/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
@@ -33,7 +33,7 @@ The following differences to the standard C++ range algorithms apply:
   In that case, the returned value contains iterators pointing to the positions past the last elements
   processed according to the algorithm semantics.
 - ``for_each`` does not return its function object.
-- ``reverse_copy`` returns ``std::ranges::in_in_out_result`` rather than its alias,
+- ``reverse_copy`` returns ``std::ranges::in_in_out_result`` rather than the alias,
   ``std::ranges::reverse_copy_truncated_result``, which is proposed for C++26 in
   `P3709R2 <https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3709r2.html>`_.
 

--- a/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
+++ b/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
@@ -429,47 +429,6 @@ Copying Mutating Operations
                                std::ranges::borrowed_iterator_t<OutR>>
         move (ExecutionPolicy&& pol, R&& r, OutR&& result);
 
-    // partition_copy
-    template <typename ExecutionPolicy, std::ranges::random_access_range R,
-          std::ranges::random_access_range OutR1, std::ranges::random_access_range OutR2,
-          typename Proj = std::identity,
-          std::indirect_unary_predicate< std::projected<std::ranges::iterator_t<R>, Proj> > Pred>
-      requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>> &&
-           std::ranges::sized_range<R> && std::ranges::sized_range<OutR1> &&
-           std::ranges::sized_range<OutR2> &&
-           std::indirectly_copyable<std::ranges::iterator_t<R>, std::ranges::iterator_t<OutR1>> &&
-           std::indirectly_copyable<std::ranges::iterator_t<R>, std::ranges::iterator_t<OutR2>>
-      std::ranges::partition_copy_result<std::ranges::borrowed_iterator_t<R>,
-                                         std::ranges::borrowed_iterator_t<OutR1>,
-                                         std::ranges::borrowed_iterator_t<OutR2>>
-      partition_copy (ExecutionPolicy&& pol, R&& r, OutR1&& out_true_r, OutR2&& out_false_r,
-                      Pred pred, Proj proj = {});
-
-    // remove_copy
-    template <typename ExecutionPolicy, std::ranges::random_access_range R,
-              std::ranges::random_access_range OutR, typename Proj = std::identity,
-              typename T = /*projected-value-type*/<std::ranges::iterator_t<R>, Proj>>
-      requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>> &&
-               std::ranges::sized_range<R> && std::ranges::sized_range<OutR> &&
-               std::indirectly_copyable<std::ranges::iterator_t<R>, std::ranges::iterator_t<OutR>> &&
-               std::indirect_binary_predicate< std::ranges::equal_to,
-                                               std::projected<std::ranges::iterator_t<R>, Proj>,
-                                               const T* >
-      std::ranges::remove_copy_result<std::ranges::borrowed_iterator_t<R>,
-                                      std::ranges::borrowed_iterator_t<OutR>>
-        remove_copy (ExecutionPolicy&& pol, R&& r, OutR&& result, const T& value, Proj proj = {});
-
-    // remove_copy_if
-    template <typename ExecutionPolicy, std::ranges::random_access_range R,
-              std::ranges::random_access_range OutR, typename Proj = std::identity,
-              std::indirect_unary_predicate< std::projected<std::ranges::iterator_t<R>, Proj> > Pred>
-      requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>> &&
-               std::ranges::sized_range<R> && std::ranges::sized_range<OutR> &&
-               std::indirectly_copyable<std::ranges::iterator_t<R>, std::ranges::iterator_t<OutR>>
-      std::ranges::remove_copy_if_result<std::ranges::borrowed_iterator_t<R>,
-                                         std::ranges::borrowed_iterator_t<OutR>>
-        remove_copy_if (ExecutionPolicy&& pol, R&& r, OutR&& result, Pred pred, Proj proj = {});
-
     // reverse_copy
     template <typename ExecutionPolicy, std::ranges::random_access_range R,
               std::ranges::random_access_range OutR>
@@ -479,17 +438,6 @@ Copying Mutating Operations
       std::ranges::reverse_copy_result<std::ranges::borrowed_iterator_t<R>,
                                        std::ranges::borrowed_iterator_t<OutR>>
         reverse_copy (ExecutionPolicy&& pol, R&& r, OutR&& result);
-
-    // rotate_copy
-    template <typename ExecutionPolicy, std::ranges::random_access_range R,
-              std::ranges::random_access_range OutR>
-      requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>> &&
-               std::ranges::sized_range<R> && std::ranges::sized_range<OutR> &&
-               std::indirectly_copyable<std::ranges::iterator_t<R>, std::ranges::iterator_t<OutR>>
-      std::ranges::rotate_copy_result<std::ranges::borrowed_iterator_t<R>,
-                                      std::ranges::borrowed_iterator_t<OutR>>
-        rotate_copy (ExecutionPolicy&& pol, R&& r, std::ranges::iterator_t<R> middle,
-                     OutR&& result);
 
     // transform (unary)
     template <typename ExecutionPolicy, std::ranges::random_access_range R,

--- a/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
+++ b/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
@@ -32,10 +32,10 @@ The following differences to the standard C++ serial range algorithms apply:
 - For algorithms with bounded output ranges, processing may not need to go over all the input data.
   In that case, the returned value contains iterators pointing to the positions past the last elements
   processed according to the algorithm semantics.
-- ``for_each`` does not return its function object.
-- ``reverse_copy`` returns ``std::ranges::in_in_out_result`` rather than the alias,
-  ``std::ranges::reverse_copy_truncated_result``, which is proposed for C++26 in
-  `P3709R2 <https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3709r2.html>`_.
+- The return type of ``reverse_copy`` is ``std::ranges::in_in_out_result``
+  rather than ``std::ranges::reverse_copy_result``.
+  The semantics of the returned value are as specified in
+  `P3709R2 <https://isocpp.org/files/papers/P3709R2.html>`_.
 
 Except for these differences, the signatures of parallel range algorithms correspond to the working draft
 of the next edition of the C++ standard (C++26).

--- a/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
+++ b/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
@@ -33,8 +33,8 @@ The following differences to the standard C++ range algorithms apply:
   In that case, the returned value contains iterators pointing to the positions past the last elements
   processed according to the algorithm semantics.
 - ``for_each`` does not return its function object.
-- ``reverse_copy_truncated_result`` alias used by ``reverse_copy`` resides in ``namespace oneapi::dpl::ranges``
-  instead of ``namespace std::ranges``.
+- ``reverse_copy`` returns ``std::ranges::in_in_out_result`` rather than its alias,
+  ``std::ranges::reverse_copy_truncated_result``.
 
 Except for these differences, the signatures of parallel range algorithms correspond to the working draft
 of the next edition of the C++ standard (C++26).
@@ -42,19 +42,14 @@ of the next edition of the C++ standard (C++26).
 Auxiliary Definitions
 +++++++++++++++++++++
 
-The following auxiliary entities are defined to aid the specification of parallel range algorithms.
+The following auxiliary entities are only defined for the purpose of exposition, to aid the specification
+of parallel range algorithms.
 
 .. code:: cpp
 
    // C++20 analogue of std::projected_value_t; exposition only
    template<typename I, typename Proj>
    using /*projected-value-type*/ = std::remove_cvref_t<std::invoke_result_t<Proj&, std::iter_value_t<I>&>>;
-
-  // C++20 analogue of std::ranges::reverse_copy_truncated_result
-  namespace oneapi::dpl::ranges {
-    template<typename I, typename O>
-    using reverse_copy_truncated_result = std::ranges::in_in_out_result<I, I, O>;
-  }
 
 Whole Sequence Operations
 +++++++++++++++++++++++++
@@ -442,8 +437,9 @@ Copying Mutating Operations
       requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>> &&
                std::ranges::sized_range<R> && std::ranges::sized_range<OutR> &&
                std::indirectly_copyable<std::ranges::iterator_t<R>, std::ranges::iterator_t<OutR>>
-      oneapi::dpl::ranges::reverse_copy_truncated_result<std::ranges::borrowed_iterator_t<R>,
-                                                         std::ranges::borrowed_iterator_t<OutR>>
+      std::ranges::in_in_out_result<std::ranges::borrowed_iterator_t<R>,
+                                    std::ranges::borrowed_iterator_t<R>,
+                                    std::ranges::borrowed_iterator_t<OutR>>
         reverse_copy (ExecutionPolicy&& pol, R&& r, OutR&& result);
 
     // transform (unary)

--- a/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
+++ b/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
@@ -33,6 +33,8 @@ The following differences to the standard C++ range algorithms apply:
   In that case, the returned value contains iterators pointing to the positions past the last elements
   processed according to the algorithm semantics.
 - ``for_each`` does not return its function object.
+- ``reverse_copy_truncated_result`` alias used by ``reverse_copy`` resides in ``namespace oneapi::dpl::ranges``
+  instead of ``namespace std::ranges``.
 
 Except for these differences, the signatures of parallel range algorithms correspond to the working draft
 of the next edition of the C++ standard (C++26).
@@ -40,14 +42,19 @@ of the next edition of the C++ standard (C++26).
 Auxiliary Definitions
 +++++++++++++++++++++
 
-The following auxiliary entities are only defined for the purpose of exposition, to aid the specification
-of parallel range algorithms.
+The following auxiliary entities are defined to aid the specification of parallel range algorithms.
 
 .. code:: cpp
 
    // C++20 analogue of std::projected_value_t; exposition only
    template<typename I, typename Proj>
    using /*projected-value-type*/ = std::remove_cvref_t<std::invoke_result_t<Proj&, std::iter_value_t<I>&>>;
+
+  // C++20 analogue of std::ranges::reverse_copy_truncated_result
+  namespace oneapi::dpl::ranges {
+    template<typename I, typename O>
+    using reverse_copy_truncated_result = std::ranges::in_in_out_result<I, I, O>;
+  }
 
 Whole Sequence Operations
 +++++++++++++++++++++++++
@@ -435,8 +442,8 @@ Copying Mutating Operations
       requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>> &&
                std::ranges::sized_range<R> && std::ranges::sized_range<OutR> &&
                std::indirectly_copyable<std::ranges::iterator_t<R>, std::ranges::iterator_t<OutR>>
-      std::ranges::reverse_copy_result<std::ranges::borrowed_iterator_t<R>,
-                                       std::ranges::borrowed_iterator_t<OutR>>
+      oneapi::dpl::ranges::reverse_copy_truncated_result<std::ranges::borrowed_iterator_t<R>,
+                                                         std::ranges::borrowed_iterator_t<OutR>>
         reverse_copy (ExecutionPolicy&& pol, R&& r, OutR&& result);
 
     // transform (unary)

--- a/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
+++ b/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
@@ -34,7 +34,8 @@ The following differences to the standard C++ range algorithms apply:
   processed according to the algorithm semantics.
 - ``for_each`` does not return its function object.
 - ``reverse_copy`` returns ``std::ranges::in_in_out_result`` rather than its alias,
-  ``std::ranges::reverse_copy_truncated_result``.
+  ``std::ranges::reverse_copy_truncated_result``, which is proposed for C++26 in
+  [P3709R2](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3709r2.html).
 
 Except for these differences, the signatures of parallel range algorithms correspond to the working draft
 of the next edition of the C++ standard (C++26).

--- a/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
+++ b/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
@@ -429,6 +429,68 @@ Copying Mutating Operations
                                std::ranges::borrowed_iterator_t<OutR>>
         move (ExecutionPolicy&& pol, R&& r, OutR&& result);
 
+    // partition_copy
+    template <typename ExecutionPolicy, std::ranges::random_access_range R,
+          std::ranges::random_access_range OutR1, std::ranges::random_access_range OutR2,
+          typename Proj = std::identity,
+          std::indirect_unary_predicate< std::projected<std::ranges::iterator_t<R>, Proj> > Pred>
+      requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>> &&
+           std::ranges::sized_range<R> && std::ranges::sized_range<OutR1> &&
+           std::ranges::sized_range<OutR2> &&
+           std::indirectly_copyable<std::ranges::iterator_t<R>, std::ranges::iterator_t<OutR1>> &&
+           std::indirectly_copyable<std::ranges::iterator_t<R>, std::ranges::iterator_t<OutR2>>
+      std::ranges::partition_copy_result<std::ranges::borrowed_iterator_t<R>,
+                                         std::ranges::borrowed_iterator_t<OutR1>,
+                                         std::ranges::borrowed_iterator_t<OutR2>>
+      partition_copy (ExecutionPolicy&& pol, R&& r, OutR1&& out_true_r, OutR2&& out_false_r,
+                      Pred pred, Proj proj = {});
+
+    // remove_copy
+    template <typename ExecutionPolicy, std::ranges::random_access_range R,
+              std::ranges::random_access_range OutR, typename Proj = std::identity,
+              typename T = /*projected-value-type*/<std::ranges::iterator_t<R>, Proj>>
+      requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>> &&
+               std::ranges::sized_range<R> && std::ranges::sized_range<OutR> &&
+               std::indirectly_copyable<std::ranges::iterator_t<R>, std::ranges::iterator_t<OutR>> &&
+               std::indirect_binary_predicate< std::ranges::equal_to,
+                                               std::projected<std::ranges::iterator_t<R>, Proj>,
+                                               const T* >
+      std::ranges::remove_copy_result<std::ranges::borrowed_iterator_t<R>,
+                                      std::ranges::borrowed_iterator_t<OutR>>
+        remove_copy (ExecutionPolicy&& pol, R&& r, OutR&& result, const T& value, Proj proj = {});
+
+    // remove_copy_if
+    template <typename ExecutionPolicy, std::ranges::random_access_range R,
+              std::ranges::random_access_range OutR, typename Proj = std::identity,
+              std::indirect_unary_predicate< std::projected<std::ranges::iterator_t<R>, Proj> > Pred>
+      requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>> &&
+               std::ranges::sized_range<R> && std::ranges::sized_range<OutR> &&
+               std::indirectly_copyable<std::ranges::iterator_t<R>, std::ranges::iterator_t<OutR>>
+      std::ranges::remove_copy_if_result<std::ranges::borrowed_iterator_t<R>,
+                                         std::ranges::borrowed_iterator_t<OutR>>
+        remove_copy_if (ExecutionPolicy&& pol, R&& r, OutR&& result, Pred pred, Proj proj = {});
+
+    // reverse_copy
+    template <typename ExecutionPolicy, std::ranges::random_access_range R,
+              std::ranges::random_access_range OutR>
+      requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>> &&
+               std::ranges::sized_range<R> && std::ranges::sized_range<OutR> &&
+               std::indirectly_copyable<std::ranges::iterator_t<R>, std::ranges::iterator_t<OutR>>
+      std::ranges::reverse_copy_result<std::ranges::borrowed_iterator_t<R>,
+                                       std::ranges::borrowed_iterator_t<OutR>>
+        reverse_copy (ExecutionPolicy&& pol, R&& r, OutR&& result);
+
+    // rotate_copy
+    template <typename ExecutionPolicy, std::ranges::random_access_range R,
+              std::ranges::random_access_range OutR>
+      requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>> &&
+               std::ranges::sized_range<R> && std::ranges::sized_range<OutR> &&
+               std::indirectly_copyable<std::ranges::iterator_t<R>, std::ranges::iterator_t<OutR>>
+      std::ranges::rotate_copy_result<std::ranges::borrowed_iterator_t<R>,
+                                      std::ranges::borrowed_iterator_t<OutR>>
+        rotate_copy (ExecutionPolicy&& pol, R&& r, std::ranges::iterator_t<R> middle,
+                     OutR&& result);
+
     // transform (unary)
     template <typename ExecutionPolicy, std::ranges::random_access_range R,
               std::ranges::random_access_range OutR, std::copy_constructible Fn,
@@ -457,6 +519,18 @@ Copying Mutating Operations
                                            std::ranges::borrowed_iterator_t<OutR>>
         transform (ExecutionPolicy&& pol, R1&& r1, R2&& r2, OutR&& result, Fn binary_op,
                    Proj1 proj1 = {}, Proj2 proj2 = {});
+
+    // unique_copy
+    template <typename ExecutionPolicy, std::ranges::random_access_range R,
+              std::ranges::random_access_range OutR, typename Proj = std::identity,
+              std::indirect_equivalence_relation< std::projected<std::ranges::iterator_t<R>, Proj> >
+                    Comp = std::ranges::equal_to>
+      requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>> &&
+               std::ranges::sized_range<R> && std::ranges::sized_range<OutR> &&
+               std::indirectly_copyable<std::ranges::iterator_t<R>, std::ranges::iterator_t<OutR>>
+      std::ranges::unique_copy_result<std::ranges::borrowed_iterator_t<R>,
+                                      std::ranges::borrowed_iterator_t<OutR>>
+        unique_copy (ExecutionPolicy&& pol, R&& r, OutR&& result, Comp comp = {}, Proj proj = {});
 
   }
 

--- a/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
+++ b/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
@@ -475,7 +475,7 @@ Copying Mutating Operations
     // unique_copy
     template <typename ExecutionPolicy, std::ranges::random_access_range R,
               std::ranges::random_access_range OutR, typename Proj = std::identity,
-              std::indirect_equivalence_relation< std::projected<std::ranges::iterator_t<R>, Proj> >
+              std::indirect_equivalence_relation<std::projected<std::ranges::iterator_t<R>, Proj>>
                     Comp = std::ranges::equal_to>
       requires oneapi::dpl::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>> &&
                std::ranges::sized_range<R> && std::ranges::sized_range<OutR> &&


### PR DESCRIPTION
Adding `reverse_copy` and `unique_copy` parallel range algorithms into oneDPL specification.

