### PR TITLE
[oneDPL] Clarify the differences with C++20 range algorithms

### DIFF
--- a/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
+++ b/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
@@ -19,7 +19,7 @@ predefined function objects which static function call operators have the requir
 
 The following differences to the standard serial C++ range algorithms apply:
 
-- Allow list initialization of value parameters, as in the working draft of the next C++ standard edition (C++26)
+- Allow list initialization of value parameters, as in the working draft of the next C++ standard edition (C++26).
 - Parallel range algorithms cannot be used in constant expressions.
 - The oneDPL execution policy parameter is added.
 - Output data sequences are defined as ranges, not iterators.

--- a/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
+++ b/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
@@ -35,6 +35,9 @@ The following differences to the standard serial C++ range algorithms apply:
   processed according to the algorithm semantics.
 - ``for_each`` does not return its function object.
 
+[*Note*: These oneDPL algorithms mostly match the semantics of the parallel range algorithms in the C++26 working draft.
+-- *end note*]
+
 Auxiliary Definitions
 +++++++++++++++++++++
 

--- a/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
+++ b/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
@@ -19,7 +19,7 @@ predefined function objects which static function call operators have the requir
 
 The following differences to the standard serial C++ range algorithms apply:
 
-- Allow list initialization of value parameters, as in the working draft of the next C++ standard edition (C++26).
+- List initialization of value parameters is enabled, as in the working draft of the next C++ standard edition (C++26).
 - Parallel range algorithms cannot be used in constant expressions.
 - The oneDPL execution policy parameter is added.
 - Output data sequences are defined as ranges, not iterators.

--- a/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
+++ b/source/elements/oneDPL/source/parallel_api/parallel_range_api.rst
@@ -17,8 +17,9 @@ defined by the C++ standard in ``namespace std::ranges``, they cannot be found b
 and cannot be called with explicitly specified template arguments. [*Note*: A typical implementation uses
 predefined function objects which static function call operators have the required signatures. -- *end note*]
 
-The following differences to the standard C++ range algorithms apply:
+The following differences to the standard serial C++ range algorithms apply:
 
+- Allow list initialization of value parameters, as in the working draft of the next C++ standard edition (C++26)
 - Parallel range algorithms cannot be used in constant expressions.
 - The oneDPL execution policy parameter is added.
 - Output data sequences are defined as ranges, not iterators.
@@ -33,9 +34,6 @@ The following differences to the standard C++ range algorithms apply:
   In that case, the returned value contains iterators pointing to the positions past the last elements
   processed according to the algorithm semantics.
 - ``for_each`` does not return its function object.
-
-Except for these differences, the signatures of parallel range algorithms correspond to the working draft
-of the next edition of the C++ standard (C++26).
 
 Auxiliary Definitions
 +++++++++++++++++++++


### PR DESCRIPTION
A small change that clarifies the differences of oneDPL parallel range algorithms with the standard ones. The change is editorial, with no modifications of API semantics.