### PR TITLE
[oneTBB] Improve named requirements to better deal with value categories

### DIFF
--- a/source/elements/oneTBB/source/algorithms/functions/parallel_for_each_func.rst
+++ b/source/elements/oneTBB/source/algorithms/functions/parallel_for_each_func.rst
@@ -42,7 +42,8 @@ Requirements:
 * If ``InputIterator`` type does not meet the `Forward Iterator` requirements from the [forward.iterators] section of the ISO C++ Standard,
   the ``std::iterator_traits<InputIterator>::value_type`` type must be constructible from ``std::iterator_traits<InputIterator>::reference``.
 * The ``Container`` type must meet the :doc:`ContainerBasedSequence requirements <../../named_requirements/algorithms/container_based_sequence>`.
-* The type returned by ``Container::begin()`` must meet the same requirements as the ``InputIterator`` type above.
+* The type returned by ``std::begin`` and ``std::end`` applied to a ``Container`` object
+  must meet the same requirements as the ``InputIterator`` type above.
 
 The ``parallel_for_each`` template has two forms.
 

--- a/source/elements/oneTBB/source/named_requirements.rst
+++ b/source/elements/oneTBB/source/named_requirements.rst
@@ -22,9 +22,14 @@ an array to be sorted. A type ``T`` would be *sortable* if:
 
 You can write a sorting template function in C++ that sorts an array of any type that is *sortable*.
 
+.. _pseudo_signatures:
+
+Pseudo-Signatures
+-----------------
+
 Two approaches for defining named requirements are *valid expressions* and *pseudo-signatures*.
 The ISO C++ standard follows the valid *expressions* approach, which shows what the usage pattern looks like for a requirement.
-It has the drawback of relegating important details to notational conventions. This document uses
+It has the drawback of relegating important details to notational conventions. This document mostly uses
 pseudo-signatures because they are concise and can be cut-and-pasted for an initial implementation.
 
 For example, the table below shows pseudo-signatures for a *sortable* type ``T``:
@@ -43,12 +48,18 @@ For example, the table below shows pseudo-signatures for a *sortable* type ``T``
 
 ---------------------------------------------------------------------------------------------
 
+A pseudo-signature describes how an implementation interacts with a type or a function.
 A real signature may differ from the pseudo-signature that it implements in ways where implicit
-conversions would deal with the difference. For an example type ``U``, the real signature that
-implements ``operator<`` in the table above can be expressed as ``int operator<( U x, U y )``,
-because C++ permits implicit conversion from ``int`` to ``bool``, and implicit conversion from ``U``
-to (``const U&``). Similarly, the real signature ``bool operator<( U& x, U& y )`` is acceptable
-because C++ permits implicit addition of a const qualifier to a reference type.
+conversions would deal with the difference: function parameters need to implicitly convert
+from the ones in the pseudo-signature, and return value needs to implicitly convert to the one
+in the pseudo-signature.
+
+For an example type ``U``, the real signature that implements ``operator<`` in the table above 
+can be expressed as ``int operator<( U x, U y )``, because C++ permits implicit conversion from
+``int`` to ``bool``, and implicit conversion from ``const U&`` to ``U`` if the type is copyable.
+For a counter-example, the real signature ``bool operator<( U& x, U& y )`` is not acceptable
+because C++ does not permit implicit removal of a const qualifier from a type, and so the code
+would not compile if the implementation attempts to pass a const object to the function.
 
 Algorithms
 ----------
@@ -81,7 +92,6 @@ Mutexes
 
 Containers
 ----------
-
 .. toctree::
    :titlesonly:
 

--- a/source/elements/oneTBB/source/named_requirements/algorithms/container_based_sequence.rst
+++ b/source/elements/oneTBB/source/named_requirements/algorithms/container_based_sequence.rst
@@ -7,17 +7,12 @@ ContainerBasedSequence
 ======================
 **[req.container_based_sequence]**
 
-A type `C` satisfies `ContainerBasedSequence` if it meets the following requirements:
+A type `C` satisfies `ContainerBasedSequence` if the following expressions are valid
+for an object ``c`` of type (possibly ``const``) ``C``:
 
 ----------------------------------------------------------------
 
-**ContainerBasedSequence Requirements: Pseudo-Signature, Semantics**
-
-    .. note::
-
-         In this page ``c`` is an object of type (possibly ``const``) ``C``.
-
-         Templates that use the named requirement can impose stricter requirements on the iterator concept.
+**ContainerBasedSequence Requirements: Expression, Semantics**
 
 .. cpp:function:: std::begin(c)
 
@@ -26,6 +21,13 @@ A type `C` satisfies `ContainerBasedSequence` if it meets the following requirem
 .. cpp:function:: std::end(c)
 
     Returns an input iterator one past the end of the sequence represented by ``c``.
+
+----------------------------------------------------------------
+
+.. note::
+
+   Templates that use ``ContainerBasedSequence`` may impose stricter requirements on the iterator type
+   returned by ``std::begin``/``std::end``.
 
 See also:
 

--- a/source/elements/oneTBB/source/named_requirements/algorithms/par_for_each_body.rst
+++ b/source/elements/oneTBB/source/named_requirements/algorithms/par_for_each_body.rst
@@ -15,46 +15,28 @@ It should also meet one of the following requirements:
 
 **ParallelForEachBody Requirements: Pseudo-Signature, Semantics**
 
-.. cpp:function:: Body::operator()( ItemType item ) const
+.. cpp:function:: void Body::operator()( ReferenceType item ) const
 
     Process the received item.
 
-.. cpp:function:: Body::operator()( ItemType item, oneapi::tbb::feeder<ItemType>& feeder ) const
+.. cpp:function:: void Body::operator()( ItemType&& item, oneapi::tbb::feeder<ItemType>& feeder ) const
 
-    Process the received item. May invoke the ``feeder.add(T)`` function to spawn additional items.
+    Process the received item. May invoke the ``feeder.add`` function to spawn additional items.
 
 -----------------------------------------------------------------
 
+where ``ItemType`` is ``std::iterator_traits<InputIterator>::value_type`` for the type of the iterator
+the ``parallel_for_each`` algorithm operates with, and ``ReferenceType`` is
+
+* ``std::iterator_traits<InputIterator>::reference`` if the iterator type is a forward iterator
+  as described in the [forward.iterators] section of the ISO C++ Standard;
+* otherwise, ``ItemType&&``.
+
 .. note::
 
-    ``ItemType`` may be optionally passed to ``Body::operator()`` by reference.
+    The usual rules for :ref:`pseudo-signatures <pseudo_signatures>` apply.
+    Therefore, ``Body::operator()`` may optionally take ``ItemType`` by value.
     ``const`` and ``volatile`` type qualifiers are also applicable.
-
-Terms
------
-
-* ``iterator`` determines the type of the iterator passed into the ``parallel_for_each`` algorithm,
-  which is ``decltype(std::begin(c))`` for the overloads that accept the ``Container`` template argument or ``InputIterator``.
-* ``value_type`` - the type ``std::iterator_traits<iterator>::value_type``.
-* ``reference`` -  the type ``std::iterator_traits<iterator>::reference``.
-
-``oneapi::tbb::parallel_for_each`` requires the ``Body::operator()`` call with an object of the ``reference`` type to be well-formed if
-the ``iterator`` meets the `Forward iterator` requirements described in the [forward.iterators] section of the 
-ISO C++ Standard.
-
-`oneapi::tbb::parallel_for_each algorithm <../../algorithms/functions/parallel_for_each_func>`_
-requires the ``Body::operator()`` call with an object of type ``const value_type&`` or ``value_type&&`` to be well-formed if following requirements are met:
-
-* the iterator meets the `Input iterator` requirements described in the [input.iterators] section of the ISO C++ Standard
-* the iterator does not meet the `Forward iterator` requirements described in the [forward.iterators] section of the ISO C++ Standard
-
-.. caution::
-
-  If the ``Body`` only takes non-const lvalue reference to the ``value_type``, the requirements described above
-  are violated, and the program can be ill-formed.
-
-Additional elements submitted into ``oneapi::tbb::parallel_for_each`` through the ``feeder::add`` are passed to the ``Body`` as rvalues. In this case, the corresponding
-execution of the ``Body`` is required to be well-formed.
 
 See also:
 


### PR DESCRIPTION
This patch attempts to clarify how named requirements are defined, especially for dealing with various value categories a function can be applied to.

Using these clarifications, the definition of ParallelForEachBody is changed to be simpler,  while the semantics should remain the same (unless I missed some nuances).